### PR TITLE
Removing build dependencies from the Makefile now that we are using go modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,6 @@ $(GATEWAY_BINARY): main.go ws_controller.go management.go job_receiver.go
 
 deps:
 	go get -u golang.org/x/lint/golint
-	go get -u github.com/google/uuid
-	go get -u github.com/spf13/viper
-	go get -u github.com/segmentio/kafka-go
 
 test:
 	go test $(TEST_ARGS) ./...

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/segmentio/kafka-go v0.3.4
 	github.com/spf13/viper v1.6.1
 )
+
+go 1.13


### PR DESCRIPTION
I'm removing the build dependencies from the Makefile but leaving the deps rule so that it can be used to install golint.  Let me know if there is a better way to do this.