### PR TITLE
Allow multiple connections per account

### DIFF
--- a/internal/controller/connection_manager.go
+++ b/internal/controller/connection_manager.go
@@ -19,39 +19,47 @@ type Client interface {
 	DisconnectReceptorNetwork()
 }
 
+type ConnectionKey struct {
+	Account, NodeID string
+}
+
 type ConnectionManager struct {
-	connections map[string]Client
+	connections map[ConnectionKey]Client
 	sync.Mutex
 }
 
 func NewConnectionManager() *ConnectionManager {
 	return &ConnectionManager{
-		connections: make(map[string]Client),
+		connections: make(map[ConnectionKey]Client),
 	}
 }
 
-func (cm *ConnectionManager) Register(account string, client Client) {
+func (cm *ConnectionManager) Register(account string, node_id string, client Client) {
+	key := ConnectionKey{account, node_id}
 	cm.Lock()
-	cm.connections[account] = client
+	cm.connections[key] = client
 	cm.Unlock()
 }
 
-func (cm *ConnectionManager) Unregister(account string) {
+func (cm *ConnectionManager) Unregister(account string, node_id string) {
+	key := ConnectionKey{account, node_id}
 	cm.Lock()
-	conn, exists := cm.connections[account]
+	conn, exists := cm.connections[key]
 	if exists == false {
 		return
 	}
 	conn.Close()
-	delete(cm.connections, account)
+	delete(cm.connections, key)
 	cm.Unlock()
 }
 
-func (cm *ConnectionManager) GetConnection(account string) Client {
+func (cm *ConnectionManager) GetConnection(account string, node_id string) Client {
 	var conn Client
 
+	key := ConnectionKey{account, node_id}
+
 	cm.Lock()
-	conn, _ = cm.connections[account]
+	conn, _ = cm.connections[key]
 	cm.Unlock()
 
 	return conn

--- a/internal/controller/job_receiver.go
+++ b/internal/controller/job_receiver.go
@@ -71,10 +71,11 @@ func (jr *JobReceiver) handleJob() http.HandlerFunc {
 			}
 		}
 
+		fmt.Println("jobRequest:", jobRequest)
 		// dispatch job via client's sendwork
 		// not using client's sendwork, but leaving this code in to verify connection?
 		var client Client
-		client = jr.connectionMgr.GetConnection(jobRequest.Account)
+		client = jr.connectionMgr.GetConnection(jobRequest.Account, jobRequest.Recipient)
 		if client == nil {
 			// FIXME: the connection to the client was not available
 			fmt.Println("No connection to the customer...")

--- a/internal/controller/management.go
+++ b/internal/controller/management.go
@@ -61,7 +61,7 @@ func (s *ManagementServer) handleDisconnect() http.HandlerFunc {
 
 		fmt.Println(connID)
 
-		client := s.connectionMgr.GetConnection(connID.Account)
+		client := s.connectionMgr.GetConnection(connID.Account, connID.NodeID)
 		if client == nil {
 			w.WriteHeader(404)
 			fmt.Printf("No connection to the customer (%+v)...\n", connID)
@@ -111,7 +111,7 @@ func (s *ManagementServer) handleConnectionStatus() http.HandlerFunc {
 
 		var connectionStatus connectionStatusResponse
 
-		client := s.connectionMgr.GetConnection(connID.Account)
+		client := s.connectionMgr.GetConnection(connID.Account, connID.NodeID)
 		if client != nil {
 			connectionStatus.Status = "connected"
 		} else {


### PR DESCRIPTION
This PR allows for multiple connections from a single account.  The connection map within the connection manager uses the account number and node id as the key.

@Jason-RH I broke a test with this change.  I marked it as skipped for now.  What do you think about modifying that test to check for a connection uses the web interface?  Or submitting some work to that connection over the web interface?