### PR TITLE
Use the context from the http request to coordinate shutdown of the go routines related to the http request

### DIFF
--- a/internal/controller/ws_controller_test.go
+++ b/internal/controller/ws_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/RedHatInsights/platform-receptor-controller/internal/receptor/protocol"
 	"go.uber.org/goleak"
@@ -116,6 +117,23 @@ var _ = Describe("WsController", func() {
 
 				m := readSocket(c, 1)
 				Expect(m.Type()).To(Equal(protocol.HiMessageType))
+			})
+		})
+	})
+
+	Describe("Connecting to the receptor controller with a handshake that takes too long", func() {
+		Context("With an open connection and trying to read from the connection", func() {
+			It("Should in return receive connection closed error", func() {
+
+				Skip("Skipping for now.  This test needs to be able to configure the websocket timeouts.")
+
+				c, _, err := d.Dial("ws://localhost:8080/wss/receptor-controller/gateway", header)
+				Expect(err).NotTo(HaveOccurred())
+				defer c.Close()
+
+				c.SetReadDeadline(time.Now().Add(2 * time.Second))
+				_, _, err = c.NextReader()
+				Expect(err).Should(MatchError(&websocket.CloseError{Code: 1006, Text: "unexpected EOF"}))
 			})
 		})
 	})


### PR DESCRIPTION
Use the context from the http request to coordinate shutdown of the go routines related to the http request [RHCLOUD-3769]
Add ping/pong handlers to implement a keepalive [RHCLOUD-3711]

This is admittedly incomplete.  This need to have more automated tests and the timeouts need to be configurable.  However, I would like to push this out and see how it behaves in the real world (behind akamai, 3scale, openshift, etc).