### PR TITLE
[WIP] decouple "work dispatcher" from websocket handling code

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -23,7 +23,7 @@ func main() {
 
 	wsMux := mux.NewRouter()
 	cm := c.NewConnectionManager()
-	rc := c.NewReceptorController(cm, wsMux)
+	rc := c.NewReceptorController(cm, wsMux, c.Consume)
 	rc.Routes()
 
 	mgmtMux := mux.NewRouter()


### PR DESCRIPTION
Playing around with the idea of making a "WorkDispatcher" which reads work requests from an unspecified location and sends the work to the client's send channel.

This is currently passing the kafka consumer logic around as a function pointer.  I think it would be better to make a WorkDispatcher factory that the websocket client can use to create an new instance of a WorkDispatcher.