### PR TITLE
Moving the websocket code around

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	c "github.com/RedHatInsights/platform-receptor-controller/internal/controller"
+	"github.com/RedHatInsights/platform-receptor-controller/internal/controller/ws"
 
 	"github.com/RedHatInsights/platform-receptor-controller/internal/platform/queue"
 	"github.com/gorilla/handlers"
@@ -23,7 +24,7 @@ func main() {
 
 	wsMux := mux.NewRouter()
 	cm := c.NewConnectionManager()
-	rc := c.NewReceptorController(cm, wsMux)
+	rc := ws.NewReceptorController(cm, wsMux)
 	rc.Routes()
 
 	mgmtMux := mux.NewRouter()

--- a/internal/controller/ws/handler.go
+++ b/internal/controller/ws/handler.go
@@ -1,0 +1,84 @@
+package ws
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/RedHatInsights/platform-receptor-controller/internal/controller"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/websocket"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+)
+
+const (
+	socketBufferSize  = 1024
+	messageBufferSize = 256
+)
+
+type ReceptorController struct {
+	connectionMgr *controller.ConnectionManager
+	router        *mux.Router
+}
+
+func NewReceptorController(cm *controller.ConnectionManager, r *mux.Router) *ReceptorController {
+	return &ReceptorController{
+		connectionMgr: cm,
+		router:        r,
+	}
+}
+
+var upgrader = &websocket.Upgrader{ReadBufferSize: socketBufferSize, WriteBufferSize: socketBufferSize}
+
+func (rc *ReceptorController) Routes() {
+	rc.router.HandleFunc("/wss/receptor-controller/gateway", rc.handleWebSocket())
+	rc.router.Use(identity.EnforceIdentity)
+}
+
+func (rc *ReceptorController) handleWebSocket() http.HandlerFunc {
+
+	return func(w http.ResponseWriter, req *http.Request) {
+
+		socket, err := upgrader.Upgrade(w, req, nil)
+		if err != nil {
+			log.Println("Upgrade error:", err)
+			return
+		}
+
+		rhIdentity := identity.Get(req.Context())
+
+		log.Println("WebSocket server - got a connection, account #", rhIdentity.Identity.AccountNumber)
+		log.Println("All the headers: ", req.Header)
+
+		client := &rcClient{
+			account: rhIdentity.Identity.AccountNumber,
+			socket:  socket,
+			send:    make(chan controller.Work, messageBufferSize),
+		}
+
+		ctx := req.Context()
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		client.cancel = cancel
+
+		socket.SetReadLimit(maxMessageSize)
+
+		defer socket.Close()
+
+		peerID, err := performHandshake(client.socket)
+		if err != nil {
+			log.Println("Error during handshake:", err)
+			return
+		}
+
+		rc.connectionMgr.Register(client.account, peerID, client)
+
+		// once this go routine exits...notify the connection manager of the clients departure
+		defer func() {
+			rc.connectionMgr.Unregister(client.account, peerID)
+			log.Println("Websocket server - account unregistered from connection manager")
+		}()
+
+		client.read(ctx)
+	}
+}

--- a/internal/controller/ws/handler_test.go
+++ b/internal/controller/ws/handler_test.go
@@ -1,4 +1,4 @@
-package controller
+package ws
 
 import (
 	"encoding/base64"
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/RedHatInsights/platform-receptor-controller/internal/controller"
 	"github.com/RedHatInsights/platform-receptor-controller/internal/receptor/protocol"
 	"go.uber.org/goleak"
 
@@ -47,7 +48,7 @@ var _ = Describe("WsController", func() {
 	var (
 		identity string
 		wsMux    *mux.Router
-		cm       *ConnectionManager
+		cm       *controller.ConnectionManager
 		rc       *ReceptorController
 		d        *websocket.Dialer
 		header   http.Header
@@ -55,7 +56,7 @@ var _ = Describe("WsController", func() {
 
 	BeforeEach(func() {
 		wsMux = mux.NewRouter()
-		cm = NewConnectionManager()
+		cm = controller.NewConnectionManager()
 		rc = NewReceptorController(cm, wsMux)
 		rc.Routes()
 
@@ -162,7 +163,7 @@ var _ = Describe("WsController", func() {
 				// client is nil below.
 				client := rc.connectionMgr.GetConnection("540155", nodeID)
 
-				workRequest := Work{MessageID: "123",
+				workRequest := controller.Work{MessageID: "123",
 					Recipient: "TestClient",
 					RouteList: []string{"test-b", "test-a"},
 					Payload:   "hello",

--- a/internal/controller/ws/ws_suite_test.go
+++ b/internal/controller/ws/ws_suite_test.go
@@ -1,4 +1,4 @@
-package controller_test
+package ws_test
 
 import (
 	"testing"


### PR DESCRIPTION
There's too much going on in the ws_controller.go nowadays.  This PR splits up the huge ws_controller.go file into smaller chunks with each chunk having the logic for a specific purpose.  I hope this makes it easier to determine which logic goes, what's happening where, etc.

@Jason-RH please take a look and let me know what you think.  Let me know if you see an approach that makes more sense, etc.  Also, please make sure I didn't break your BDD tests.  I believe I got them working but please take a look and make sure it looks okay to you.