### PR TITLE
Changing the kafka configuration env var names

### DIFF
--- a/internal/platform/queue/config.go
+++ b/internal/platform/queue/config.go
@@ -1,7 +1,24 @@
 package queue
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/spf13/viper"
+)
+
+const (
+	ENV_PREFIX = "RECEPTOR_CONTROLLER"
+
+	BROKERS = "Kafka_Brokers"
+
+	JOBS_TOPIC           = "Kafka_Jobs_Topic"
+	JOBS_GROUP_ID        = "Kafka_Jobs_Group_Id"
+	JOBS_CONSUMER_OFFSET = "Kafka_Jobs_Consumer_Offset"
+
+	RESPONSES_TOPIC = "Kafka_Responses_Topic"
+
+	DEFAULT_BROKER_ADDRESS = "kafka:29092"
 )
 
 type ConsumerConfig struct {
@@ -11,33 +28,53 @@ type ConsumerConfig struct {
 	ConsumerOffset int64
 }
 
+func (cc *ConsumerConfig) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s: %s\n", BROKERS, cc.Brokers)
+	fmt.Fprintf(&b, "%s: %s\n", JOBS_TOPIC, cc.Topic)
+	fmt.Fprintf(&b, "%s: %s\n", JOBS_GROUP_ID, cc.GroupID)
+	fmt.Fprintf(&b, "%s: %d\n", JOBS_CONSUMER_OFFSET, cc.ConsumerOffset)
+	return b.String()
+}
+
 type ProducerConfig struct {
 	Brokers []string
 	Topic   string
 }
 
+func (pc *ProducerConfig) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s: %s\n", BROKERS, pc.Brokers)
+	fmt.Fprintf(&b, "%s: %s\n", RESPONSES_TOPIC, pc.Topic)
+	return b.String()
+}
+
 func GetConsumer() *ConsumerConfig {
 	options := viper.New()
-	options.SetDefault("Brokers", []string{"kafka:29092"})
-	options.SetDefault("Topic", "platform.receptor-controller.jobs")
-	options.SetDefault("GroupID", "receptor-controller")
-	options.SetDefault("ConsumerOffset", -1)
+	options.SetDefault(BROKERS, []string{DEFAULT_BROKER_ADDRESS})
+	options.SetDefault(JOBS_TOPIC, "platform.receptor-controller.jobs")
+	options.SetDefault(JOBS_GROUP_ID, "receptor-controller")
+	options.SetDefault(JOBS_CONSUMER_OFFSET, -1)
+	options.SetEnvPrefix(ENV_PREFIX)
+	options.AutomaticEnv()
 
 	return &ConsumerConfig{
-		Brokers:        options.GetStringSlice("Brokers"),
-		Topic:          options.GetString("Topic"),
-		GroupID:        options.GetString("GroupID"),
-		ConsumerOffset: options.GetInt64("ConsumerOffset"),
+		Brokers:        options.GetStringSlice(BROKERS),
+		Topic:          options.GetString(JOBS_TOPIC),
+		GroupID:        options.GetString(JOBS_GROUP_ID),
+		ConsumerOffset: options.GetInt64(JOBS_CONSUMER_OFFSET),
 	}
 }
 
 func GetProducer() *ProducerConfig {
 	options := viper.New()
-	options.SetDefault("Brokers", []string{"kafka:29092"})
-	options.SetDefault("Topic", "platform.receptor-controller.responses")
+	options.SetDefault(BROKERS, []string{DEFAULT_BROKER_ADDRESS})
+	options.SetDefault(RESPONSES_TOPIC, "platform.receptor-controller.responses")
+	options.SetEnvPrefix(ENV_PREFIX)
+	options.AutomaticEnv()
 
 	return &ProducerConfig{
-		Brokers: options.GetStringSlice("Brokers"),
-		Topic:   options.GetString("Topic"),
+		Brokers: options.GetStringSlice(BROKERS),
+		Topic:   options.GetString(RESPONSES_TOPIC),
 	}
 }

--- a/internal/platform/queue/consumer.go
+++ b/internal/platform/queue/consumer.go
@@ -8,6 +8,7 @@ import (
 
 func StartConsumer(cfg *ConsumerConfig) *kafka.Reader {
 	log.Println("Starting a new kafka consumer...")
+	log.Println("Kafka consumer configuration: ", cfg)
 
 	r := kafka.NewReader(kafka.ReaderConfig{
 		Brokers:     cfg.Brokers,

--- a/internal/platform/queue/producer.go
+++ b/internal/platform/queue/producer.go
@@ -8,6 +8,7 @@ import (
 
 func StartProducer(cfg *ProducerConfig) *kafka.Writer {
 	log.Println("Starting a new Kafka producer..")
+	log.Println("Kafka producer configuration: ", cfg)
 
 	w := kafka.NewWriter(kafka.WriterConfig{
 		Brokers: cfg.Brokers,


### PR DESCRIPTION
Changing the kafka configuration env var names
Modified the kafka consumer/producer config structs to implement the stringer interface.  Used to dump the configuration details to the logs.