### PR TITLE
Add OpenAPI 3 spec for the internal interface

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -2,7 +2,9 @@
 
 set -e
 
-INSTALL_DIR=/opt/app-root/src/bin
+BASE_DIR=/opt/app-root/src
+INSTALL_DIR=$BASE_DIR/bin
+API_SPEC_DIR=$BASE_DIR/apispec
 
 echo
 echo "===> Build started at $(date)"
@@ -28,6 +30,10 @@ echo "---> Copying binaries into place..."
 mkdir -p $INSTALL_DIR
 cp gateway $INSTALL_DIR
 cp job-receiver $INSTALL_DIR
+
+echo "---> Copying openapi spec into place..."
+mkdir -p $API_SPEC_DIR
+cp internal/controller/apispec/api.spec.json $API_SPEC
 
 echo
 echo "===> Build completed at $(date)"

--- a/cmd/job_receiver/main.go
+++ b/cmd/job_receiver/main.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	c "github.com/RedHatInsights/platform-receptor-controller/internal/controller"
+	"github.com/RedHatInsights/platform-receptor-controller/internal/controller/api"
 
 	"github.com/RedHatInsights/platform-receptor-controller/internal/platform/queue"
 	"github.com/gorilla/mux"
@@ -21,12 +22,12 @@ func main() {
 
 	cm := c.NewConnectionManager()
 	mgmtMux := mux.NewRouter()
-	mgmtServer := c.NewManagementServer(cm, mgmtMux)
+	mgmtServer := api.NewManagementServer(cm, mgmtMux)
 	mgmtServer.Routes()
 
 	kw := queue.StartProducer(queue.GetProducer())
 
-	jr := c.NewJobReceiver(cm, mgmtMux, kw)
+	jr := api.NewJobReceiver(cm, mgmtMux, kw)
 	jr.Routes()
 
 	go func() {

--- a/internal/controller/api/api.spec.json
+++ b/internal/controller/api/api.spec.json
@@ -1,0 +1,161 @@
+{
+  "openapi": "3.0.0",
+  "servers": [
+    {
+      "description": "Local Receptor-Controller API",
+      "url": "/api/receptor-controller/v1/"
+    }
+  ],
+  "info": {
+    "description": "Service for routing work requests originating from within cloud.redhat.com to receptor nodes within a customer's environment\n",
+    "version": "1.0.0",
+    "title": "Receptor-Controller",
+    "contact": {
+      "email": "dehort@redhat.com"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "tags": [
+    {
+      "name": "api",
+      "description": "RESTful service"
+    }
+  ],
+  "paths": {
+    "/job": {
+      "post": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Submit a job request to be routed to a customers environment",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JobRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No connection to the target receptor node"
+          }
+        }
+      }
+    },
+    "/connection/status": {
+      "post": {
+        "tags": [
+          "api"
+        ],
+        "summary": "Submit a job request to be routed to a customers environment",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConnectionStatusRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectionStatusResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-rh-identity",
+        "description": "Base64-encoded JSON identity header provided by 3Scale. Contains an account number of the user issuing the request. Format of the JSON: {\"identity\": {\"account_number\": \"12345678\"}}"
+      }
+    },
+    "schemas": {
+      "JobResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "JobRequest": {
+        "type": "object",
+        "properties": {
+          "account": {
+            "type": "string"
+          },
+          "recipient": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object"
+          },
+          "directive": {
+            "type": "string"
+          }
+        }
+      },
+      "ConnectionStatusRequest": {
+        "type": "object",
+        "properties": {
+          "account": {
+            "type": "string"
+          },
+          "node_id": {
+            "type": "string"
+          }
+        }
+      },
+      "ConnectionStatusResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "connected",
+              "disconnected"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/controller/api/management.go
+++ b/internal/controller/api/management.go
@@ -1,4 +1,4 @@
-package controller
+package api
 
 import (
 	"encoding/json"
@@ -7,16 +7,17 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/RedHatInsights/platform-receptor-controller/internal/controller"
+
 	"github.com/gorilla/mux"
-	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
 type ManagementServer struct {
-	connectionMgr *ConnectionManager
+	connectionMgr *controller.ConnectionManager
 	router        *mux.Router
 }
 
-func NewManagementServer(cm *ConnectionManager, r *mux.Router) *ManagementServer {
+func NewManagementServer(cm *controller.ConnectionManager, r *mux.Router) *ManagementServer {
 	return &ManagementServer{
 		connectionMgr: cm,
 		router:        r,
@@ -26,7 +27,6 @@ func NewManagementServer(cm *ConnectionManager, r *mux.Router) *ManagementServer
 func (s *ManagementServer) Routes() {
 	s.router.HandleFunc("/connection/disconnect", s.handleDisconnect())
 	s.router.HandleFunc("/connection/status", s.handleConnectionStatus())
-	s.router.Use(identity.EnforceIdentity)
 }
 
 type connectionID struct {

--- a/internal/controller/api/spec_handler.go
+++ b/internal/controller/api/spec_handler.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+type ApiSpecServer struct {
+	router *mux.Router
+}
+
+func NewApiSpecServer(r *mux.Router) *ApiSpecServer {
+	return &ApiSpecServer{
+		router: r,
+	}
+}
+
+func (s *ApiSpecServer) Routes() {
+	s.router.HandleFunc("/openapi.json", s.handleApiSpec()).Methods("GET")
+}
+
+func (s *ApiSpecServer) handleApiSpec() http.HandlerFunc {
+
+	return func(w http.ResponseWriter, req *http.Request) {
+		apiSpecFileName := "/opt/apt-root/src/apispec/api.spec.json"
+		file, err := ioutil.ReadFile(apiSpecFileName)
+		if err != nil {
+			log.Printf("Unable to read API spec file (%s): %s", apiSpecFileName, err)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		w.Write(file)
+	}
+}


### PR DESCRIPTION
Initial attempt at making an openapi spec
Moved the identity middleware configuration up to the main() method and created a secured api mux
Adding logic into the build scripts to move the apispec to the right place during the openshift build
Moving the job_receiver and management handler code into the controller/api directory