### PR TITLE
Fix a bug where the payload message builder was not using the message id

### DIFF
--- a/internal/controller/api/job_receiver.go
+++ b/internal/controller/api/job_receiver.go
@@ -87,7 +87,7 @@ func (jr *JobReceiver) handleJob() http.HandlerFunc {
 			return
 		}
 
-		jobID, err := uuid.NewUUID()
+		jobID, err := uuid.NewRandom()
 		if err != nil {
 			log.Println("Unable to generate UUID for routing the job...cannot proceed")
 			return
@@ -97,7 +97,7 @@ func (jr *JobReceiver) handleJob() http.HandlerFunc {
 
 		log.Println("job request:", jobRequest)
 
-		workRequest := controller.Work{MessageID: jobID.String(),
+		workRequest := controller.Work{MessageID: jobID,
 			Recipient: jobRequest.Recipient,
 			RouteList: []string{"node-b", "node-a"},
 			Payload:   jobRequest.Payload,

--- a/internal/controller/connection_manager.go
+++ b/internal/controller/connection_manager.go
@@ -2,10 +2,12 @@ package controller
 
 import (
 	"sync"
+
+	"github.com/google/uuid"
 )
 
 type Work struct {
-	MessageID string
+	MessageID uuid.UUID
 	Recipient string
 	RouteList []string
 	Payload   interface{}

--- a/internal/controller/ws/client.go
+++ b/internal/controller/ws/client.go
@@ -116,6 +116,7 @@ func (c *rcClient) write(ctx context.Context) {
 			log.Println("Websocket writer needs to send msg:", msg)
 
 			payloadMessage, messageID, err := protocol.BuildPayloadMessage(
+				msg.MessageID,
 				c.config.ReceptorControllerNodeId,
 				msg.Recipient,
 				msg.RouteList,

--- a/internal/controller/ws/handler_test.go
+++ b/internal/controller/ws/handler_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 	"github.com/posener/wstest"
@@ -171,7 +172,10 @@ var _ = Describe("WsController", func() {
 				// client is nil below.
 				client := rc.connectionMgr.GetConnection("540155", nodeID)
 
-				workRequest := controller.Work{MessageID: "123",
+				messageID, err := uuid.NewRandom()
+				Expect(err).NotTo(HaveOccurred())
+
+				workRequest := controller.Work{MessageID: messageID,
 					Recipient: "TestClient",
 					RouteList: []string{"test-b", "test-a"},
 					Payload:   "hello",

--- a/internal/receptor/protocol/messages.go
+++ b/internal/receptor/protocol/messages.go
@@ -322,17 +322,11 @@ func (jt *Time) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func BuildPayloadMessage(sender string, recipient string, route []string,
+func BuildPayloadMessage(messageId uuid.UUID, sender string, recipient string, route []string,
 	messageType string, directive string, payload interface{}) (Message, *uuid.UUID, error) {
 	routingMessage := RoutingMessage{Sender: sender,
 		Recipient: recipient,
 		RouteList: route,
-	}
-
-	messageId, err := uuid.NewUUID()
-	if err != nil {
-		log.Println("unable to generate uuid for message:", err)
-		return nil, nil, err
 	}
 
 	innerMessage := InnerEnvelope{


### PR DESCRIPTION
that was generated and handed back to the job submitter.
Changed the way the message ids are generated.