### PR TITLE
Removing kafka consuming repsonsibility out of the websocket client

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -37,8 +37,8 @@ func main() {
 	kw := queue.StartProducer(queue.GetProducer())
 	kc := queue.GetConsumer()
 	rd := c.NewResponseDispatcherFactory(kw)
-	wd := c.NewWorkDispatcherFactory(kc)
-	rc := ws.NewReceptorController(wsConfig, cm, wsMux, rd, wd)
+	md := c.NewMessageDispatcherFactory(kc)
+	rc := ws.NewReceptorController(wsConfig, cm, wsMux, rd, md)
 	rc.Routes()
 
 	apiMux := mux.NewRouter()

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -35,8 +35,10 @@ func main() {
 
 	cm := c.NewConnectionManager()
 	kw := queue.StartProducer(queue.GetProducer())
-	d := c.NewResponseDispatcherFactory(kw)
-	rc := ws.NewReceptorController(wsConfig, cm, wsMux, d)
+	kc := queue.GetConsumer()
+	rd := c.NewResponseDispatcherFactory(kw)
+	wd := c.NewWorkDispatcherFactory(kc)
+	rc := ws.NewReceptorController(wsConfig, cm, wsMux, rd, wd)
 	rc.Routes()
 
 	apiMux := mux.NewRouter()

--- a/internal/controller/ws/client.go
+++ b/internal/controller/ws/client.go
@@ -26,7 +26,7 @@ type rcClient struct {
 
 	responseDispatcher *controller.ResponseDispatcher
 
-	workDispatcher *controller.WorkDispatcher
+	messageDispatcher *controller.MessageDispatcher
 
 	config *WebSocketConfig
 }

--- a/internal/controller/ws/client.go
+++ b/internal/controller/ws/client.go
@@ -74,7 +74,7 @@ func (c *rcClient) read(ctx context.Context) {
 		log.Printf("Websocket reader message: %+v\n", message)
 		log.Println("Websocket reader message type:", message.Type())
 
-		c.responseDispatcher.Dispatch(ctx, message, c.config.ReceptorControllerNodeId)
+		c.responseDispatcher.DispatchResponse(ctx, message, c.config.ReceptorControllerNodeId)
 	}
 }
 

--- a/internal/controller/ws/handler.go
+++ b/internal/controller/ws/handler.go
@@ -92,7 +92,7 @@ func (rc *ReceptorController) handleWebSocket() http.HandlerFunc {
 
 		// Should the client have a 'handler' function that manages the connection?
 		// ex. setting up ping pong, timeouts, cleanup, and calling the goroutines
-		go client.workDispatcher.Dispatch(ctx, client.send)
+		go client.workDispatcher.StartDispatchingMessages(ctx, client.send)
 		go client.write(ctx)
 		client.read(ctx)
 	}

--- a/internal/controller/ws/handler.go
+++ b/internal/controller/ws/handler.go
@@ -21,16 +21,16 @@ type ReceptorController struct {
 	router                    *mux.Router
 	config                    *WebSocketConfig
 	responseDispatcherFactory *controller.ResponseDispatcherFactory
-	workDispatcherFactory     *controller.WorkDispatcherFactory
+	messageDispatcherFactory  *controller.MessageDispatcherFactory
 }
 
-func NewReceptorController(wsc *WebSocketConfig, cm *controller.ConnectionManager, r *mux.Router, rd *controller.ResponseDispatcherFactory, wd *controller.WorkDispatcherFactory) *ReceptorController {
+func NewReceptorController(wsc *WebSocketConfig, cm *controller.ConnectionManager, r *mux.Router, rd *controller.ResponseDispatcherFactory, md *controller.MessageDispatcherFactory) *ReceptorController {
 	return &ReceptorController{
 		connectionMgr:             cm,
 		router:                    r,
 		config:                    wsc,
 		responseDispatcherFactory: rd,
-		workDispatcherFactory:     wd,
+		messageDispatcherFactory:  md,
 	}
 }
 
@@ -65,7 +65,7 @@ func (rc *ReceptorController) handleWebSocket() http.HandlerFunc {
 		}
 
 		client.responseDispatcher = rc.responseDispatcherFactory.NewDispatcher(client.account, client.node_id)
-		client.workDispatcher = rc.workDispatcherFactory.NewDispatcher(client.account, client.node_id)
+		// client.messageDispatcher = rc.messageDispatcherFactory.NewDispatcher(client.account, client.node_id)
 
 		ctx := req.Context()
 		ctx, cancel := context.WithCancel(ctx)
@@ -92,7 +92,7 @@ func (rc *ReceptorController) handleWebSocket() http.HandlerFunc {
 
 		// Should the client have a 'handler' function that manages the connection?
 		// ex. setting up ping pong, timeouts, cleanup, and calling the goroutines
-		go client.workDispatcher.StartDispatchingMessages(ctx, client.send)
+		// go client.messageDispatcher.StartDispatchingMessages(ctx, client.send)
 		go client.write(ctx)
 		client.read(ctx)
 	}


### PR DESCRIPTION
The work dispatcher will handle consuming job messages from the job router. Also removed the go routines for write and dispatch out of read and into the handler to further simplify read.