### PR TITLE
Start moving more logic into the receptor service object

### DIFF
--- a/internal/controller/api/job_receiver.go
+++ b/internal/controller/api/job_receiver.go
@@ -78,7 +78,7 @@ func (jr *JobReceiver) handleJob() http.HandlerFunc {
 		log.Println("jobRequest:", jobRequest)
 		// dispatch job via client's sendwork
 		// not using client's sendwork, but leaving this code in to verify connection?
-		var client controller.Client
+		var client controller.Receptor
 		client = jr.connectionMgr.GetConnection(jobRequest.Account, jobRequest.Recipient)
 		if client == nil {
 			// FIXME: the connection to the client was not available

--- a/internal/controller/api/job_receiver.go
+++ b/internal/controller/api/job_receiver.go
@@ -10,8 +10,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/google/uuid"
-
 	"github.com/RedHatInsights/platform-receptor-controller/internal/controller"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 
@@ -87,33 +85,24 @@ func (jr *JobReceiver) handleJob() http.HandlerFunc {
 			return
 		}
 
-		jobID, err := uuid.NewRandom()
+		log.Println("job request:", jobRequest)
+
+		jobID, err := client.SendMessage(jobRequest.Recipient,
+			[]string{jobRequest.Recipient},
+			jobRequest.Payload,
+			jobRequest.Directive)
+
 		if err != nil {
-			log.Println("Unable to generate UUID for routing the job...cannot proceed")
-			return
+			// FIXME:  Handle this better!?!?
+			log.Println("Error passing message to receptor: ", err)
+			w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			if err := json.NewEncoder(w).Encode(err); err != nil {
+				panic(err)
+			}
 		}
 
 		jobResponse := JobResponse{jobID.String()}
-
-		log.Println("job request:", jobRequest)
-
-		workRequest := controller.Message{MessageID: jobID,
-			Recipient: jobRequest.Recipient,
-			RouteList: []string{jobRequest.Recipient},
-			Payload:   jobRequest.Payload,
-			Directive: jobRequest.Directive}
-
-		client.SendMessage(workRequest)
-
-		/*
-			// dispatch job via kafka queue
-			jobRequestJSON, err := json.Marshal(jobRequest)
-			jr.producer.WriteMessages(context.Background(),
-				kafka.Message{
-					Key:   []byte(jobRequest.Account),
-					Value: []byte(jobRequestJSON),
-				})
-		*/
 
 		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 		w.WriteHeader(http.StatusCreated)

--- a/internal/controller/api/job_receiver_test.go
+++ b/internal/controller/api/job_receiver_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/RedHatInsights/platform-receptor-controller/internal/controller"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 )
 
@@ -22,7 +23,9 @@ const (
 type MockClient struct {
 }
 
-func (mc MockClient) SendMessage(w controller.Message) {
+func (mc MockClient) SendMessage(recipient string, route []string, payload interface{}, directive string) (*uuid.UUID, error) {
+	myUUID, _ := uuid.NewRandom()
+	return &myUUID, nil
 }
 
 func (mc MockClient) Close() {

--- a/internal/controller/connection_manager.go
+++ b/internal/controller/connection_manager.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 )
 
-type Client interface {
+type Receptor interface {
 	SendMessage(Message)
 	Close()
 	DisconnectReceptorNetwork()
@@ -15,17 +15,17 @@ type ConnectionKey struct {
 }
 
 type ConnectionManager struct {
-	connections map[ConnectionKey]Client
+	connections map[ConnectionKey]Receptor
 	sync.Mutex
 }
 
 func NewConnectionManager() *ConnectionManager {
 	return &ConnectionManager{
-		connections: make(map[ConnectionKey]Client),
+		connections: make(map[ConnectionKey]Receptor),
 	}
 }
 
-func (cm *ConnectionManager) Register(account string, node_id string, client Client) {
+func (cm *ConnectionManager) Register(account string, node_id string, client Receptor) {
 	key := ConnectionKey{account, node_id}
 	cm.Lock()
 	cm.connections[key] = client
@@ -44,8 +44,8 @@ func (cm *ConnectionManager) Unregister(account string, node_id string) {
 	cm.Unlock()
 }
 
-func (cm *ConnectionManager) GetConnection(account string, node_id string) Client {
-	var conn Client
+func (cm *ConnectionManager) GetConnection(account string, node_id string) Receptor {
+	var conn Receptor
 
 	key := ConnectionKey{account, node_id}
 

--- a/internal/controller/connection_manager.go
+++ b/internal/controller/connection_manager.go
@@ -2,10 +2,12 @@ package controller
 
 import (
 	"sync"
+
+	"github.com/google/uuid"
 )
 
 type Receptor interface {
-	SendMessage(Message)
+	SendMessage(string, []string, interface{}, string) (*uuid.UUID, error)
 	Close()
 	DisconnectReceptorNetwork()
 }

--- a/internal/controller/disconnect_handler.go
+++ b/internal/controller/disconnect_handler.go
@@ -12,7 +12,7 @@ type DisconnectHandler struct {
 	NodeID         string
 	ControlChannel chan protocol.Message
 	ErrorChannel   chan error
-	Receptor       *Receptor
+	Receptor       *ReceptorService
 	Dispatcher     IResponseDispatcher
 	ConnectionMgr  *ConnectionManager
 }

--- a/internal/controller/handshake_handler.go
+++ b/internal/controller/handshake_handler.go
@@ -43,7 +43,7 @@ func (hh HandshakeHandler) HandleMessage(ctx context.Context, m protocol.Message
 
 	hh.Receptor.RegisterConnection(hiMessage.ID, hiMessage.Metadata)
 
-	hh.ConnectionMgr.Register(hh.AccountNumber, hiMessage.ID, hh.Receptor) // FIXME:
+	hh.ConnectionMgr.Register(hh.AccountNumber, hiMessage.ID, hh.Receptor)
 
 	disconnectHandler := DisconnectHandler{
 		AccountNumber: hh.AccountNumber,

--- a/internal/controller/handshake_handler.go
+++ b/internal/controller/handshake_handler.go
@@ -13,7 +13,7 @@ type HandshakeHandler struct {
 	Send                     chan<- Message
 	ControlChannel           chan protocol.Message
 	ErrorChannel             chan error
-	Receptor                 *Receptor
+	Receptor                 *ReceptorService
 	Dispatcher               IResponseDispatcher
 	ConnectionMgr            *ConnectionManager
 	MessageDispatcherFactory *MessageDispatcherFactory
@@ -43,7 +43,7 @@ func (hh HandshakeHandler) HandleMessage(ctx context.Context, m protocol.Message
 
 	hh.Receptor.RegisterConnection(hiMessage.ID, hiMessage.Metadata)
 
-	hh.ConnectionMgr.Register(hh.AccountNumber, hiMessage.ID, nil) // FIXME:
+	hh.ConnectionMgr.Register(hh.AccountNumber, hiMessage.ID, hh.Receptor) // FIXME:
 
 	disconnectHandler := DisconnectHandler{
 		AccountNumber: hh.AccountNumber,

--- a/internal/controller/payload_handler.go
+++ b/internal/controller/payload_handler.go
@@ -17,7 +17,7 @@ type PayloadHandler struct {
 
 	ControlChannel chan protocol.Message
 	ErrorChannel   chan error
-	Receptor       *Receptor
+	Receptor       *ReceptorService
 }
 
 func (ph *PayloadHandler) GetKey() string {

--- a/internal/controller/payload_handler.go
+++ b/internal/controller/payload_handler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/RedHatInsights/platform-receptor-controller/internal/platform/queue"
 	"github.com/RedHatInsights/platform-receptor-controller/internal/receptor/protocol"
 	kafka "github.com/segmentio/kafka-go"
 )
@@ -13,7 +14,6 @@ import (
 type PayloadHandler struct {
 	AccountNumber string
 	NodeID        string
-	Writer        *kafka.Writer
 
 	ControlChannel chan protocol.Message
 	ErrorChannel   chan error
@@ -72,7 +72,8 @@ func (ph PayloadHandler) HandleMessage(ctx context.Context, m protocol.Message) 
 		return nil
 	}
 
-	ph.Writer.WriteMessages(ctx,
+	kw := queue.StartProducer(queue.GetProducer())
+	kw.WriteMessages(ctx,
 		kafka.Message{
 			Key:   []byte(payloadMessage.Data.InResponseTo),
 			Value: jsonResponseMessage,

--- a/internal/controller/receptor.go
+++ b/internal/controller/receptor.go
@@ -4,6 +4,8 @@ import (
 	"log"
 
 	"github.com/RedHatInsights/platform-receptor-controller/internal/receptor/protocol"
+
+	"github.com/google/uuid"
 )
 
 type ReceptorService struct {
@@ -40,8 +42,23 @@ func (r *ReceptorService) UpdateRoutingTable(edges string, seen string) error {
 	return nil
 }
 
-func (r *ReceptorService) SendMessage(msg Message) {
+func (r *ReceptorService) SendMessage(recipient string, route []string, payload interface{}, directive string) (*uuid.UUID, error) {
+
+	jobID, err := uuid.NewRandom()
+	if err != nil {
+		log.Println("Unable to generate UUID for routing the job...cannot proceed")
+		return nil, err
+	}
+
+	msg := Message{MessageID: jobID,
+		Recipient: recipient,
+		RouteList: route,
+		Payload:   payload,
+		Directive: directive}
+
 	r.SendChannel <- msg
+
+	return &jobID, nil
 }
 
 func (r *ReceptorService) Close() {

--- a/internal/controller/receptor.go
+++ b/internal/controller/receptor.go
@@ -2,6 +2,8 @@ package controller
 
 import (
 	"log"
+
+	"github.com/RedHatInsights/platform-receptor-controller/internal/receptor/protocol"
 )
 
 type ReceptorService struct {
@@ -10,6 +12,11 @@ type ReceptorService struct {
 	PeerNodeID string
 
 	Metadata interface{}
+
+	// FIXME:  Move the channels into a Transport object/struct
+	SendChannel    chan<- Message
+	ControlChannel chan<- protocol.Message
+	ErrorChannel   chan<- error
 
 	/*
 	   edges
@@ -33,7 +40,8 @@ func (r *ReceptorService) UpdateRoutingTable(edges string, seen string) error {
 	return nil
 }
 
-func (r *ReceptorService) SendMessage(Message) {
+func (r *ReceptorService) SendMessage(msg Message) {
+	r.SendChannel <- msg
 }
 
 func (r *ReceptorService) Close() {

--- a/internal/controller/receptor.go
+++ b/internal/controller/receptor.go
@@ -4,7 +4,7 @@ import (
 	"log"
 )
 
-type Receptor struct {
+type ReceptorService struct {
 	Account    string
 	NodeID     string
 	PeerNodeID string
@@ -17,7 +17,7 @@ type Receptor struct {
 	*/
 }
 
-func (r *Receptor) RegisterConnection(peerNodeID string, metadata interface{}) error {
+func (r *ReceptorService) RegisterConnection(peerNodeID string, metadata interface{}) error {
 	log.Printf("Registering a connection to node %s", peerNodeID)
 
 	r.PeerNodeID = peerNodeID
@@ -26,9 +26,18 @@ func (r *Receptor) RegisterConnection(peerNodeID string, metadata interface{}) e
 	return nil
 }
 
-func (r *Receptor) UpdateRoutingTable(edges string, seen string) error {
+func (r *ReceptorService) UpdateRoutingTable(edges string, seen string) error {
 	log.Println("edges:", edges)
 	log.Println("seen:", seen)
 
 	return nil
+}
+
+func (r *ReceptorService) SendMessage(Message) {
+}
+
+func (r *ReceptorService) Close() {
+}
+
+func (r *ReceptorService) DisconnectReceptorNetwork() {
 }

--- a/internal/controller/route_table_handler.go
+++ b/internal/controller/route_table_handler.go
@@ -11,7 +11,7 @@ import (
 type RouteTableHandler struct {
 	ControlChannel chan protocol.Message
 	ErrorChannel   chan error
-	Receptor       *Receptor
+	Receptor       *ReceptorService
 }
 
 func (rth RouteTableHandler) HandleMessage(ctx context.Context, m protocol.Message) error {

--- a/internal/controller/ws/handler.go
+++ b/internal/controller/ws/handler.go
@@ -76,7 +76,12 @@ func (rc *ReceptorController) handleWebSocket() http.HandlerFunc {
 
 		responseDispatcher := rc.responseDispatcherFactory.NewDispatcher(client.recv)
 
-		receptor := controller.ReceptorService{NodeID: rc.config.ReceptorControllerNodeId}
+		receptor := controller.ReceptorService{
+			NodeID:         rc.config.ReceptorControllerNodeId,
+			SendChannel:    client.send,
+			ControlChannel: client.controlChannel,
+			ErrorChannel:   client.errorChannel,
+		}
 
 		handshakeHandler := controller.HandshakeHandler{
 			Send:                     client.send,

--- a/internal/controller/ws/handler.go
+++ b/internal/controller/ws/handler.go
@@ -76,7 +76,7 @@ func (rc *ReceptorController) handleWebSocket() http.HandlerFunc {
 
 		responseDispatcher := rc.responseDispatcherFactory.NewDispatcher(client.recv)
 
-		receptor := controller.Receptor{NodeID: rc.config.ReceptorControllerNodeId}
+		receptor := controller.ReceptorService{NodeID: rc.config.ReceptorControllerNodeId}
 
 		handshakeHandler := controller.HandshakeHandler{
 			Send:                     client.send,

--- a/internal/controller/ws/handler_test.go
+++ b/internal/controller/ws/handler_test.go
@@ -16,7 +16,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 	"github.com/posener/wstest"
@@ -173,16 +172,7 @@ var _ = Describe("WsController", func() {
 				// client is nil below.
 				client := rc.connectionMgr.GetConnection("540155", nodeID)
 
-				messageID, err := uuid.NewRandom()
-				Expect(err).NotTo(HaveOccurred())
-
-				workRequest := controller.Message{MessageID: messageID,
-					Recipient: "TestClient",
-					RouteList: []string{"test-b", "test-a"},
-					Payload:   "hello",
-					Directive: "receptor:ping"}
-
-				client.SendMessage(workRequest)
+				client.SendMessage("TestClient", []string{"test-b", "test-a"}, "hello", "receptor:ping")
 
 				m := readSocket(c, 4)      // read response from SendMessage request and verify it is a PayloadMessage
 				jm, err := json.Marshal(m) // m's marshal/unmarshal functions are private and can't be used here


### PR DESCRIPTION
This PR starts moving more logic into the Receptor service object.  This PR also modifies the ConnectionManager so that it deals with the Receptor object instead of a Connection object.