### PR TITLE
Wiring up the disconnect handler

### DIFF
--- a/internal/controller/handshake_handler.go
+++ b/internal/controller/handshake_handler.go
@@ -50,7 +50,7 @@ func (hh HandshakeHandler) HandleMessage(ctx context.Context, m protocol.Message
 		NodeID:        hiMessage.ID,
 		ConnectionMgr: hh.ConnectionMgr,
 	}
-	hh.Dispatcher.RegisterHandler(protocol.DisconnectMessageType, disconnectHandler)
+	hh.Dispatcher.RegisterDisconnectHandler(disconnectHandler)
 
 	routeTableHandler := RouteTableHandler{
 		Receptor:       hh.Receptor, // FIXME: Dont care...pass in only what is required

--- a/internal/receptor/protocol/messages.go
+++ b/internal/receptor/protocol/messages.go
@@ -19,7 +19,6 @@ var (
 type NetworkMessageType int
 
 const (
-	DisconnectMessageType NetworkMessageType = -255
 	HiMessageType         NetworkMessageType = 1
 	RouteTableMessageType NetworkMessageType = 2
 	RoutingMessageType    NetworkMessageType = 3


### PR DESCRIPTION
I broke the disconnect handling logic with the recent refactorings.  This PR fixes the disconnect logic so that the receptor instance is removed from the ConnectionManager when the connection dropped.

I'm not overly happy with this approach because it creates a special case in the dispatcher. But this approach does work.