### PR TITLE
Fix RHCLOUD-5076 read timeout issue

### DIFF
--- a/internal/controller/ws/client.go
+++ b/internal/controller/ws/client.go
@@ -69,6 +69,9 @@ func (c *rcClient) read(ctx context.Context) {
 			return
 		}
 
+		// The read has completed...disable the read deadline
+		c.socket.SetReadDeadline(time.Time{})
+
 		log.Printf("Websocket reader message: %+v\n", message)
 		log.Println("Websocket reader message type:", message.Type())
 


### PR DESCRIPTION
Disable the read deadline after the read completes.  If you don't disable the read deadline, then subsequent reads can raise a timeout error.