### PR TITLE
Make the ping response look more like the status response

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,16 +81,22 @@ The response from the ping is similar to the response that is put onto the kafka
 
 ```
   {
-    "account": <account number>,
-    "sender": <node that send the response>
-    "message_type": <message type from the receptor network, usually "response">
-    "message_id": <uuid of the message from the receptor network>
-    "payload":  <response payload from the receptor network>
-    "code": 0,
-    "in_response_to": <uuid of the message that this message is in response to>
-    "serial": 1
+    "status":"connected" or "disconnected"
+    "payload":
+      {
+        "account": <account number>,
+        "sender": <node that send the response>
+        "message_type": <message type from the receptor network, usually "response">
+        "message_id": <uuid of the message from the receptor network>
+        "payload":  <response payload from the receptor network>
+        "code": 0,
+        "in_response_to": <uuid of the message that this message is in response to>
+        "serial": 1
+     }
   }
 ```
+
+If there is not a websocket connection to the node, then the status will be "disconnected" and the payload will be null.
 
 
 ### Kafka Topics

--- a/internal/controller/api/api.spec.json
+++ b/internal/controller/api/api.spec.json
@@ -123,7 +123,6 @@
         }
       }
     }
-
   },
   "components": {
     "securitySchemes": {
@@ -176,15 +175,22 @@
         "type": "object",
         "properties": {
           "status": {
-            "type": "string",
-            "enum": [
-              "connected",
-              "disconnected"
-            ]
+            "$ref": "#/components/schemas/ConnectionStatus"
           }
         }
       },
       "ConnectionPingResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/ConnectionStatus"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/Payload"
+          }
+        }
+      },
+      "Payload": {
         "type": "object",
         "properties": {
           "account": {
@@ -212,6 +218,13 @@
             "type": "integer"
           }
         }
+      },
+      "ConnectionStatus": {
+        "type": "string",
+        "enum": [
+          "connected",
+          "disconnected"
+        ]
       }
     }
   }


### PR DESCRIPTION
This PR modifies the ping response so that it looks a bit more like the status response.  The ping will return a json object that has a status field which should be either "connected" or "disconnected".  If the status is "connected", then the payload field should have the receptor's response to a ping message.  If the status is "disconnected", then the payload field will be null.