### PR TITLE
Small kafka refactor. Receptor service factory added.

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -37,8 +37,9 @@ func main() {
 	kw := queue.StartProducer(queue.GetProducer())
 	kc := queue.GetConsumer()
 	rd := c.NewResponseReactorFactory(kw)
+	rs := c.NewReceptorServiceFactory(kw)
 	md := c.NewMessageDispatcherFactory(kc)
-	rc := ws.NewReceptorController(wsConfig, cm, wsMux, rd, md)
+	rc := ws.NewReceptorController(wsConfig, cm, wsMux, rd, md, rs)
 	rc.Routes()
 
 	apiMux := mux.NewRouter()

--- a/internal/controller/ws/handler_test.go
+++ b/internal/controller/ws/handler_test.go
@@ -66,7 +66,8 @@ var _ = Describe("WsController", func() {
 		md := controller.NewMessageDispatcherFactory(kc)
 		kw = queue.StartProducer(queue.GetProducer())
 		rd := controller.NewResponseReactorFactory(kw)
-		rc = NewReceptorController(config, cm, wsMux, rd, md)
+		rs := controller.NewReceptorServiceFactory(kw)
+		rc = NewReceptorController(config, cm, wsMux, rd, md, rs)
 		rc.Routes()
 
 		d = wstest.NewDialer(rc.router)


### PR DESCRIPTION
@dehort Kept this refactor as minimal as possible for now. Basically just avoids starting the kafka producer on every connection. Created a factory for the receptor service, which currently just needs the kafka writer, and then accepts account, nodeID, and transport arguments. 