### PR TITLE
Resp react remove kafka

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -36,7 +36,7 @@ func main() {
 	cm := c.NewConnectionManager()
 	kw := queue.StartProducer(queue.GetProducer())
 	kc := queue.GetConsumer()
-	rd := c.NewResponseReactorFactory(kw)
+	rd := c.NewResponseReactorFactory()
 	rs := c.NewReceptorServiceFactory(kw)
 	md := c.NewMessageDispatcherFactory(kc)
 	rc := ws.NewReceptorController(wsConfig, cm, wsMux, rd, md, rs)

--- a/internal/controller/response_reactor.go
+++ b/internal/controller/response_reactor.go
@@ -19,27 +19,22 @@ type ResponseReactor interface {
 }
 
 type ResponseReactorFactory struct {
-	writer *kafka.Writer
 }
 
 func NewResponseReactorFactory(writer *kafka.Writer) *ResponseReactorFactory {
-	return &ResponseReactorFactory{
-		writer: writer,
-	}
+	return &ResponseReactorFactory{}
 }
 
 func (fact *ResponseReactorFactory) NewResponseReactor(recv <-chan protocol.Message) ResponseReactor {
 
 	log.Println("Creating a new response dispatcher")
 	return &ResponseReactorImpl{
-		writer:   fact.writer,
 		recv:     recv,
 		handlers: make(map[protocol.NetworkMessageType]MessageHandler),
 	}
 }
 
 type ResponseReactorImpl struct {
-	writer            *kafka.Writer
 	recv              <-chan protocol.Message
 	handlers          map[protocol.NetworkMessageType]MessageHandler
 	disconnectHandler MessageHandler

--- a/internal/controller/response_reactor.go
+++ b/internal/controller/response_reactor.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/RedHatInsights/platform-receptor-controller/internal/receptor/protocol"
-	kafka "github.com/segmentio/kafka-go"
 )
 
 type MessageHandler interface {
@@ -21,7 +20,7 @@ type ResponseReactor interface {
 type ResponseReactorFactory struct {
 }
 
-func NewResponseReactorFactory(writer *kafka.Writer) *ResponseReactorFactory {
+func NewResponseReactorFactory() *ResponseReactorFactory {
 	return &ResponseReactorFactory{}
 }
 

--- a/internal/controller/ws/handler_test.go
+++ b/internal/controller/ws/handler_test.go
@@ -65,7 +65,7 @@ var _ = Describe("WsController", func() {
 		kc := queue.GetConsumer()
 		md := controller.NewMessageDispatcherFactory(kc)
 		kw = queue.StartProducer(queue.GetProducer())
-		rd := controller.NewResponseReactorFactory(kw)
+		rd := controller.NewResponseReactorFactory()
 		rs := controller.NewReceptorServiceFactory(kw)
 		rc = NewReceptorController(config, cm, wsMux, rd, md, rs)
 		rc.Routes()


### PR DESCRIPTION
@dehort This may not be necessary (not sure what your future plans were for this reactor), but currently the kafka writer isn't being used in the response_reactor so this PR removes it.