### PR TITLE
Add a test to verify that the composite middleware handles the identity header authentication

### DIFF
--- a/internal/middlewares/auth_test.go
+++ b/internal/middlewares/auth_test.go
@@ -11,21 +11,29 @@ import (
 )
 
 const (
-	TOKEN_HEADER_CLIENT_NAME  = "x-rh-receptor-controller-client-id"
-	TOKEN_HEADER_ACCOUNT_NAME = "x-rh-receptor-controller-account"
-	TOKEN_HEADER_PSK_NAME     = "x-rh-receptor-controller-psk"
-	authFailure               = "Authentication failed"
+	TOKEN_HEADER_CLIENT_NAME              = "x-rh-receptor-controller-client-id"
+	TOKEN_HEADER_ACCOUNT_NAME             = "x-rh-receptor-controller-account"
+	TOKEN_HEADER_PSK_NAME                 = "x-rh-receptor-controller-psk"
+	authFailure                           = "Authentication failed"
+	IDENTITY_HEADER_NAME                  = "x-rh-identity"
+	EXPECTED_ACCOUNT_FROM_TOKEN           = "0000001"
+	VALID_IDENTITY_HEADER                 = "eyJpZGVudGl0eSI6IHsiYWNjb3VudF9udW1iZXIiOiAiMDAwMDAwMiIsICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjAwMDAwMSJ9fX0="
+	EXPECTED_ACCOUNT_FROM_IDENTITY_HEADER = "0000002"
 )
 
-func GetTestHandler() http.HandlerFunc {
-	fn := func(rw http.ResponseWriter, req *http.Request) {}
+func GetTestHandler(expectedAccountNumber string) http.HandlerFunc {
+	fn := func(rw http.ResponseWriter, req *http.Request) {
+		principal, ok := middlewares.GetPrincipal(req.Context())
+		Expect(ok).To(Equal(true))
+		Expect(principal.GetAccount()).To(Equal(expectedAccountNumber))
+	}
 
 	return http.HandlerFunc(fn)
 }
 
-func boiler(req *http.Request, expectedStatusCode int, expectedBody string, amw *middlewares.AuthMiddleware) {
+func boiler(req *http.Request, expectedStatusCode int, expectedBody string, expectedAccountNumber string, amw *middlewares.AuthMiddleware) {
 	rr := httptest.NewRecorder()
-	handler := amw.Authenticate(GetTestHandler())
+	handler := amw.Authenticate(GetTestHandler(expectedAccountNumber))
 	handler.ServeHTTP(rr, req)
 
 	Expect(rr.Code).To(Equal(expectedStatusCode))
@@ -53,26 +61,26 @@ var _ = Describe("Auth", func() {
 		Context("With no missing token auth headers", func() {
 			It("Should return 200 when the key is correct", func() {
 				req.Header.Add(TOKEN_HEADER_CLIENT_NAME, "test_client_1")
-				req.Header.Add(TOKEN_HEADER_ACCOUNT_NAME, "0000001")
+				req.Header.Add(TOKEN_HEADER_ACCOUNT_NAME, EXPECTED_ACCOUNT_FROM_TOKEN)
 				req.Header.Add(TOKEN_HEADER_PSK_NAME, "12345")
 
-				boiler(req, 200, "", amw)
+				boiler(req, 200, "", EXPECTED_ACCOUNT_FROM_TOKEN, amw)
 			})
 
 			It("Should return a 401 when the key is incorrect", func() {
 				req.Header.Add(TOKEN_HEADER_CLIENT_NAME, "test_client_1")
-				req.Header.Add(TOKEN_HEADER_ACCOUNT_NAME, "0000001")
+				req.Header.Add(TOKEN_HEADER_ACCOUNT_NAME, EXPECTED_ACCOUNT_FROM_TOKEN)
 				req.Header.Add(TOKEN_HEADER_PSK_NAME, "678910")
 
-				boiler(req, 401, authFailure+"\n", amw)
+				boiler(req, 401, authFailure+"\n", EXPECTED_ACCOUNT_FROM_TOKEN, amw)
 			})
 
 			It("Should return a 401 when the client id is unknown", func() {
 				req.Header.Add(TOKEN_HEADER_CLIENT_NAME, "test_client_nil")
-				req.Header.Add(TOKEN_HEADER_ACCOUNT_NAME, "0000001")
+				req.Header.Add(TOKEN_HEADER_ACCOUNT_NAME, EXPECTED_ACCOUNT_FROM_TOKEN)
 				req.Header.Add(TOKEN_HEADER_PSK_NAME, "12345")
 
-				boiler(req, 401, authFailure+"\n", amw)
+				boiler(req, 401, authFailure+"\n", EXPECTED_ACCOUNT_FROM_TOKEN, amw)
 			})
 		})
 
@@ -81,22 +89,35 @@ var _ = Describe("Auth", func() {
 				req.Header.Add(TOKEN_HEADER_ACCOUNT_NAME, "0000001")
 				req.Header.Add(TOKEN_HEADER_PSK_NAME, "12345")
 
-				boiler(req, 401, authFailure+"\n", amw)
+				boiler(req, 401, authFailure+"\n", "dont care", amw)
 			})
 
 			It("Should return 401 when the account header is missing", func() {
 				req.Header.Add(TOKEN_HEADER_CLIENT_NAME, "test_client_1")
 				req.Header.Add(TOKEN_HEADER_PSK_NAME, "12345")
 
-				boiler(req, 401, authFailure+"\n", amw)
+				boiler(req, 401, authFailure+"\n", "dont care", amw)
 			})
 
 			It("Should return 401 when the psk header is missing", func() {
 				req.Header.Add(TOKEN_HEADER_CLIENT_NAME, "test_client_1")
 				req.Header.Add(TOKEN_HEADER_ACCOUNT_NAME, "0000001")
 
-				boiler(req, 401, authFailure+"\n", amw)
+				boiler(req, 401, authFailure+"\n", "dont care", amw)
 			})
 		})
 	})
+
+	Describe("Use identity header authentication", func() {
+		Context("With valid identity header and no psk headers", func() {
+			It("Should return 200 when the key is correct", func() {
+				req.Header.Add(IDENTITY_HEADER_NAME, VALID_IDENTITY_HEADER)
+
+				boiler(req, 200, "", EXPECTED_ACCOUNT_FROM_IDENTITY_HEADER, amw)
+			})
+
+		})
+
+	})
+
 })


### PR DESCRIPTION
- Add a test to verify that the composite middleware handles the identity header authentication
- Modified existing tests to verify that the principal object can be retrieved and that it returns the correct account number