### PR TITLE
Add more security checks

### DIFF
--- a/internal/controller/api/job_receiver.go
+++ b/internal/controller/api/job_receiver.go
@@ -90,7 +90,7 @@ func (jr *JobReceiver) handleJob() http.HandlerFunc {
 			"directive": jobRequest.Directive})
 		logger.Info("Sending a message")
 
-		jobID, err := client.SendMessage(req.Context(), jobRequest.Recipient,
+		jobID, err := client.SendMessage(req.Context(), jobRequest.Account, jobRequest.Recipient,
 			[]string{jobRequest.Recipient},
 			jobRequest.Payload,
 			jobRequest.Directive)

--- a/internal/controller/api/job_receiver_test.go
+++ b/internal/controller/api/job_receiver_test.go
@@ -29,12 +29,12 @@ const (
 type MockClient struct {
 }
 
-func (mc MockClient) SendMessage(ctx context.Context, recipient string, route []string, payload interface{}, directive string) (*uuid.UUID, error) {
+func (mc MockClient) SendMessage(ctx context.Context, account string, recipient string, route []string, payload interface{}, directive string) (*uuid.UUID, error) {
 	myUUID, _ := uuid.NewRandom()
 	return &myUUID, nil
 }
 
-func (mc MockClient) Ping(context.Context, string, []string) (interface{}, error) {
+func (mc MockClient) Ping(context.Context, string, string, []string) (interface{}, error) {
 	return nil, nil
 }
 

--- a/internal/controller/api/management.go
+++ b/internal/controller/api/management.go
@@ -178,7 +178,7 @@ func (s *ManagementServer) handleConnectionPing() http.HandlerFunc {
 
 		pingResponse.Status = CONNECTED_STATUS
 		var err error
-		pingResponse.Payload, err = client.Ping(req.Context(), connID.NodeID, []string{connID.NodeID})
+		pingResponse.Payload, err = client.Ping(req.Context(), connID.Account, connID.NodeID, []string{connID.NodeID})
 		if err != nil {
 			errorResponse := errorResponse{Title: "Ping failed",
 				Status: http.StatusBadRequest,

--- a/internal/controller/connection_manager.go
+++ b/internal/controller/connection_manager.go
@@ -11,8 +11,8 @@ import (
 )
 
 type Receptor interface {
-	SendMessage(context.Context, string, []string, interface{}, string) (*uuid.UUID, error)
-	Ping(context.Context, string, []string) (interface{}, error)
+	SendMessage(context.Context, string, string, []string, interface{}, string) (*uuid.UUID, error)
+	Ping(context.Context, string, string, []string) (interface{}, error)
 	Close()
 	GetCapabilities() interface{}
 }

--- a/internal/controller/connection_manager_test.go
+++ b/internal/controller/connection_manager_test.go
@@ -19,11 +19,11 @@ type MockReceptor struct {
 	NodeID string
 }
 
-func (mr *MockReceptor) SendMessage(context.Context, string, []string, interface{}, string) (*uuid.UUID, error) {
+func (mr *MockReceptor) SendMessage(context.Context, string, string, []string, interface{}, string) (*uuid.UUID, error) {
 	return nil, nil
 }
 
-func (mr *MockReceptor) Ping(context.Context, string, []string) (interface{}, error) {
+func (mr *MockReceptor) Ping(context.Context, string, string, []string) (interface{}, error) {
 	return nil, nil
 }
 

--- a/internal/controller/handshake_handler.go
+++ b/internal/controller/handshake_handler.go
@@ -23,7 +23,7 @@ type HandshakeHandler struct {
 
 func (hh HandshakeHandler) HandleMessage(ctx context.Context, m protocol.Message) {
 	if m.Type() != protocol.HiMessageType {
-		hh.Transport.ErrorChannel <- SendErrorMessage{
+		hh.Transport.ErrorChannel <- ReceptorErrorMessage{
 			AccountNumber: hh.AccountNumber,
 			Error:         fmt.Errorf("Invalid message type (type: %d): %v", m.Type(), m),
 		}
@@ -32,7 +32,7 @@ func (hh HandshakeHandler) HandleMessage(ctx context.Context, m protocol.Message
 
 	hiMessage, ok := m.(*protocol.HiMessage)
 	if !ok {
-		hh.Transport.ErrorChannel <- SendErrorMessage{
+		hh.Transport.ErrorChannel <- ReceptorErrorMessage{
 			AccountNumber: hh.AccountNumber,
 			Error:         fmt.Errorf("Unable to convert message into HiMessage"),
 		}
@@ -51,7 +51,7 @@ func (hh HandshakeHandler) HandleMessage(ctx context.Context, m protocol.Message
 	case <-ctx.Done():
 		hh.Logger.Info("Request cancelled during handshake. Error: ", ctx.Err())
 		return
-	case hh.Transport.ControlChannel <- SendMessage{
+	case hh.Transport.ControlChannel <- ReceptorMessage{
 		AccountNumber: hh.AccountNumber,
 		Message:       &responseHiMessage}:
 		break
@@ -72,7 +72,7 @@ func (hh HandshakeHandler) HandleMessage(ctx context.Context, m protocol.Message
 		hh.Logger.WithFields(logrus.Fields{"error": err}).Infof("Unable to register connection "+
 			"(%s:%s) with connection manager.  Closing connection!", hh.AccountNumber, hiMessage.ID)
 
-		hh.Transport.ErrorChannel <- SendErrorMessage{
+		hh.Transport.ErrorChannel <- ReceptorErrorMessage{
 			AccountNumber: hh.AccountNumber,
 			Error:         err}
 

--- a/internal/controller/receptor.go
+++ b/internal/controller/receptor.go
@@ -165,19 +165,19 @@ func (r *ReceptorService) Ping(msgSenderCtx context.Context, account string, rec
 // FIXME:  Does it make sense to move this logic to the transport object?  Or am I missing an abstraction?
 func (r *ReceptorService) sendControlMessage(msgSenderCtx context.Context, msgToSend protocol.Message) error {
 
-	msg := SendMessage{AccountNumber: r.AccountNumber, Message: msgToSend}
+	msg := ReceptorMessage{AccountNumber: r.AccountNumber, Message: msgToSend}
 
 	return sendMessage(r.logger, r.Transport.Ctx, r.Transport.ControlChannel, msgSenderCtx, msg)
 }
 
 func (r *ReceptorService) sendMessage(msgSenderCtx context.Context, msgToSend protocol.Message) error {
 
-	msg := SendMessage{AccountNumber: r.AccountNumber, Message: msgToSend}
+	msg := ReceptorMessage{AccountNumber: r.AccountNumber, Message: msgToSend}
 
 	return sendMessage(r.logger, r.Transport.Ctx, r.Transport.Send, msgSenderCtx, msg)
 }
 
-func sendMessage(logger *logrus.Entry, transportCtx context.Context, sendChannel chan SendMessage, msgSenderCtx context.Context, msgToSend SendMessage) error {
+func sendMessage(logger *logrus.Entry, transportCtx context.Context, sendChannel chan ReceptorMessage, msgSenderCtx context.Context, msgToSend ReceptorMessage) error {
 	logger.Debug("Passing message to async layer")
 
 	select {

--- a/internal/controller/receptor.go
+++ b/internal/controller/receptor.go
@@ -21,6 +21,7 @@ var (
 	connectionToReceptorNetworkLost = errors.New("Connection to receptor network lost")
 	requestCancelledBySender        = errors.New("Unable to complete the request.  Request cancelled by message sender.")
 	requestTimedOut                 = errors.New("Unable to complete the request.  Request timed out.")
+	accountMismatch                 = errors.New("Account mismatch.  Unable to complete the request.")
 )
 
 type ReceptorServiceFactory struct {
@@ -80,7 +81,11 @@ func (r *ReceptorService) UpdateRoutingTable(edges string, seen string) error {
 	return nil
 }
 
-func (r *ReceptorService) SendMessage(msgSenderCtx context.Context, recipient string, route []string, payload interface{}, directive string) (*uuid.UUID, error) {
+func (r *ReceptorService) SendMessage(msgSenderCtx context.Context, account string, recipient string, route []string, payload interface{}, directive string) (*uuid.UUID, error) {
+
+	if account != r.AccountNumber {
+		return nil, accountMismatch
+	}
 
 	messageID, err := uuid.NewRandom()
 	if err != nil {
@@ -109,7 +114,11 @@ func (r *ReceptorService) SendMessage(msgSenderCtx context.Context, recipient st
 	return &messageID, nil
 }
 
-func (r *ReceptorService) Ping(msgSenderCtx context.Context, recipient string, route []string) (interface{}, error) {
+func (r *ReceptorService) Ping(msgSenderCtx context.Context, account string, recipient string, route []string) (interface{}, error) {
+
+	if account != r.AccountNumber {
+		return nil, accountMismatch
+	}
 
 	messageID, err := uuid.NewRandom()
 	if err != nil {

--- a/internal/controller/receptor.go
+++ b/internal/controller/receptor.go
@@ -165,15 +165,19 @@ func (r *ReceptorService) Ping(msgSenderCtx context.Context, account string, rec
 // FIXME:  Does it make sense to move this logic to the transport object?  Or am I missing an abstraction?
 func (r *ReceptorService) sendControlMessage(msgSenderCtx context.Context, msgToSend protocol.Message) error {
 
-	return sendMessage(r.logger, r.Transport.Ctx, r.Transport.ControlChannel, msgSenderCtx, msgToSend)
+	msg := SendMessage{AccountNumber: r.AccountNumber, Message: msgToSend}
+
+	return sendMessage(r.logger, r.Transport.Ctx, r.Transport.ControlChannel, msgSenderCtx, msg)
 }
 
 func (r *ReceptorService) sendMessage(msgSenderCtx context.Context, msgToSend protocol.Message) error {
 
-	return sendMessage(r.logger, r.Transport.Ctx, r.Transport.Send, msgSenderCtx, msgToSend)
+	msg := SendMessage{AccountNumber: r.AccountNumber, Message: msgToSend}
+
+	return sendMessage(r.logger, r.Transport.Ctx, r.Transport.Send, msgSenderCtx, msg)
 }
 
-func sendMessage(logger *logrus.Entry, transportCtx context.Context, sendChannel chan protocol.Message, msgSenderCtx context.Context, msgToSend protocol.Message) error {
+func sendMessage(logger *logrus.Entry, transportCtx context.Context, sendChannel chan SendMessage, msgSenderCtx context.Context, msgToSend SendMessage) error {
 	logger.Debug("Passing message to async layer")
 
 	select {

--- a/internal/controller/transport.go
+++ b/internal/controller/transport.go
@@ -6,12 +6,12 @@ import (
 	"github.com/RedHatInsights/platform-receptor-controller/internal/receptor/protocol"
 )
 
-type SendMessage struct {
+type ReceptorMessage struct {
 	AccountNumber string
 	Message       protocol.Message
 }
 
-type SendErrorMessage struct {
+type ReceptorErrorMessage struct {
 	AccountNumber string
 	Error         error
 }
@@ -19,7 +19,7 @@ type SendErrorMessage struct {
 type Transport struct {
 
 	// send is a channel on which messages are sent.
-	Send chan SendMessage
+	Send chan ReceptorMessage
 
 	// recv is a channel on which responses are sent.
 	Recv chan protocol.Message
@@ -28,11 +28,11 @@ type Transport struct {
 	// messages are passed to the write side of the websocket...
 	// this allows command/control messages to bypass any queued
 	// job messages
-	ControlChannel chan SendMessage
+	ControlChannel chan ReceptorMessage
 
 	// errorChannel is a channel on which errors are sent
 	// to the go routine managing write side of the websocket
-	ErrorChannel chan SendErrorMessage
+	ErrorChannel chan ReceptorErrorMessage
 
 	Ctx    context.Context
 	Cancel context.CancelFunc

--- a/internal/controller/transport.go
+++ b/internal/controller/transport.go
@@ -6,10 +6,20 @@ import (
 	"github.com/RedHatInsights/platform-receptor-controller/internal/receptor/protocol"
 )
 
+type SendMessage struct {
+	AccountNumber string
+	Message       protocol.Message
+}
+
+type SendErrorMessage struct {
+	AccountNumber string
+	Error         error
+}
+
 type Transport struct {
 
 	// send is a channel on which messages are sent.
-	Send chan protocol.Message
+	Send chan SendMessage
 
 	// recv is a channel on which responses are sent.
 	Recv chan protocol.Message
@@ -18,11 +28,11 @@ type Transport struct {
 	// messages are passed to the write side of the websocket...
 	// this allows command/control messages to bypass any queued
 	// job messages
-	ControlChannel chan protocol.Message
+	ControlChannel chan SendMessage
 
 	// errorChannel is a channel on which errors are sent
 	// to the go routine managing write side of the websocket
-	ErrorChannel chan error
+	ErrorChannel chan SendErrorMessage
 
 	Ctx    context.Context
 	Cancel context.CancelFunc

--- a/internal/controller/ws/client.go
+++ b/internal/controller/ws/client.go
@@ -19,11 +19,11 @@ type rcClient struct {
 	socket *websocket.Conn
 
 	// send is a channel on which messages are sent.
-	send chan controller.SendMessage
+	send chan controller.ReceptorMessage
 
-	controlChannel chan controller.SendMessage
+	controlChannel chan controller.ReceptorMessage
 
-	errorChannel chan controller.SendErrorMessage
+	errorChannel chan controller.ReceptorErrorMessage
 
 	// recv is a channel on which responses are sent.
 	recv chan protocol.Message
@@ -83,7 +83,7 @@ func (c *rcClient) configurePongHandler() {
 	}
 }
 
-func (c *rcClient) writeMessage(msg controller.SendMessage) error {
+func (c *rcClient) writeMessage(msg controller.ReceptorMessage) error {
 
 	if err := c.verifyAccountNumber(msg.AccountNumber); err != nil {
 		return err

--- a/internal/controller/ws/handler.go
+++ b/internal/controller/ws/handler.go
@@ -69,11 +69,12 @@ func (rc *ReceptorController) handleWebSocket() http.HandlerFunc {
 		logger.Info("Accepted websocket connection")
 
 		client := &rcClient{
+			account:        rhIdentity.Identity.AccountNumber,
 			config:         rc.config,
 			socket:         socket,
-			send:           make(chan protocol.Message, rc.config.BufferedChannelSize),
-			controlChannel: make(chan protocol.Message, rc.config.BufferedChannelSize),
-			errorChannel:   make(chan error),
+			send:           make(chan controller.SendMessage, rc.config.BufferedChannelSize),
+			controlChannel: make(chan controller.SendMessage, rc.config.BufferedChannelSize),
+			errorChannel:   make(chan controller.SendErrorMessage),
 			recv:           make(chan protocol.Message, rc.config.BufferedChannelSize),
 			logger:         logger,
 		}

--- a/internal/controller/ws/handler.go
+++ b/internal/controller/ws/handler.go
@@ -72,9 +72,9 @@ func (rc *ReceptorController) handleWebSocket() http.HandlerFunc {
 			account:        rhIdentity.Identity.AccountNumber,
 			config:         rc.config,
 			socket:         socket,
-			send:           make(chan controller.SendMessage, rc.config.BufferedChannelSize),
-			controlChannel: make(chan controller.SendMessage, rc.config.BufferedChannelSize),
-			errorChannel:   make(chan controller.SendErrorMessage),
+			send:           make(chan controller.ReceptorMessage, rc.config.BufferedChannelSize),
+			controlChannel: make(chan controller.ReceptorMessage, rc.config.BufferedChannelSize),
+			errorChannel:   make(chan controller.ReceptorErrorMessage),
 			recv:           make(chan protocol.Message, rc.config.BufferedChannelSize),
 			logger:         logger,
 		}


### PR DESCRIPTION
This PR adds explicit checks for the account number to the ReceptorService and to the websocket writer.  The websocket layer records the account number during the handshake.  With this PR, the ReceptorService will pass along the account number along with the message to send.  The websocket layer can compare the account number it received with the message to send against the account number that it has stored.  If the account numbers do not match, then the websocket layer discards the message.