### PR TITLE
Change the port that the gateway uses when running with docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,13 +197,28 @@ Install the project dependencies:
   $ make
 ```
 
-#### Local testing with receptor
+#### Running locally
 
 Start the server
 
 ```
   $ ./gateway
 ```
+
+By default, the receptor gateway will attempt to connect to a kafka server listening on `kafka:29092`.
+The kafka server that the receptor gateway connects to can be configured using the
+`RECEPTOR_CONTROLLER_KAFKA_BROKERS` environment variable.
+
+#### Running with Docker Compose
+
+A docker compose file is provided that starts kafka and the receptor gateway:
+
+```
+  $ docker-compose -f docker-compose.yml up
+```
+
+When using the docker-compose approach, the receptor gateway process listens on port 8888 for websocket connections.
+
 
 ##### Receptor node configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,11 +27,12 @@ services:
       context: ./
       dockerfile: ./cmd/gateway/Dockerfile
     image: platform-receptor-controller-gateway
+    command: ./ws-gateway -wsAddr gateway:8888
     ports:
-      - 8080:8080 # websocket gateway
+      - 8888:8888 # websocket gateway
       - 9090:9090 # gateway management server
     environment:
-      - PLACEHOLDER_ENV_VAR=placeholder_env_var
+      - RECEPTOR_CONTROLLER_LOG_LEVEL=debug
     depends_on:
       - kafka
   job-receiver:


### PR DESCRIPTION
Zookeeper/Kafka fails to load because of a port conflict with the gateway.  I would really like to change the port that zookeeper uses or disable the zookeeper admin interface, but that doesn't appear to be possible.  So...this change modifies the port that the gateway listens on so that the docker-compose approach to starting things up works.

The gateway will listen on port 8888 when using docker-compose.

This will help folks that are wanting to develop against the receptor-controller.