### PR TITLE
Redis connections decorator split the interface

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -27,7 +27,7 @@ const (
 	OPENAPI_SPEC_FILE = "/opt/app-root/src/api/api.spec.file"
 )
 
-func closeConnections(cm c.ConnectionManager, wg *sync.WaitGroup, timeout time.Duration) {
+func closeConnections(cm c.ConnectionLocator, wg *sync.WaitGroup, timeout time.Duration) {
 	defer wg.Done()
 	connections := cm.GetAllConnections()
 	for _, conn := range connections {
@@ -68,8 +68,8 @@ func main() {
 	}
 
 	rm := c.NewRedisManager(cfg)
-	localCM := c.NewConnectionManager()
-	gatewayCM := c.NewGatewayConnectionManager(rm, localCM)
+	localCM := c.NewLocalConnectionManager()
+	gatewayCM := c.NewGatewayConnectionRegistrar(rm, localCM)
 	rd := c.NewResponseReactorFactory()
 	rs := c.NewReceptorServiceFactory(kw, cfg)
 	md := c.NewMessageDispatcherFactory(kc)

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -68,11 +68,12 @@ func main() {
 	}
 
 	rm := c.NewRedisManager(cfg)
-	cm := c.NewConnectionManager(rm)
+	localCM := c.NewConnectionManager()
+	gatewayCM := c.NewGatewayConnectionManager(rm, localCM)
 	rd := c.NewResponseReactorFactory()
 	rs := c.NewReceptorServiceFactory(kw, cfg)
 	md := c.NewMessageDispatcherFactory(kc)
-	rc := ws.NewReceptorController(cfg, cm, wsMux, rd, md, rs)
+	rc := ws.NewReceptorController(cfg, gatewayCM, wsMux, rd, md, rs)
 	rc.Routes()
 
 	apiMux := mux.NewRouter()
@@ -81,10 +82,10 @@ func main() {
 	apiSpecServer := api.NewApiSpecServer(apiMux, OPENAPI_SPEC_FILE)
 	apiSpecServer.Routes()
 
-	mgmtServer := api.NewManagementServer(cm, apiMux, cfg)
+	mgmtServer := api.NewManagementServer(localCM, apiMux, cfg)
 	mgmtServer.Routes()
 
-	jr := api.NewJobReceiver(cm, apiMux, kw, cfg)
+	jr := api.NewJobReceiver(localCM, apiMux, kw, cfg)
 	jr.Routes()
 
 	apiMux.Handle("/metrics", promhttp.Handler())
@@ -94,7 +95,7 @@ func main() {
 
 	apiSrv := utils.StartHTTPServer(*mgmtAddr, "management", apiMux)
 	wsSrv := utils.StartHTTPServer(*wsAddr, "websocket", wsMux)
-	wsSrv.RegisterOnShutdown(func() { closeConnections(cm, wg, cfg.HttpShutdownTimeout) })
+	wsSrv.RegisterOnShutdown(func() { closeConnections(localCM, wg, cfg.HttpShutdownTimeout) })
 
 	signalChan := make(chan os.Signal, 1)
 

--- a/cmd/job_receiver/main.go
+++ b/cmd/job_receiver/main.go
@@ -23,8 +23,7 @@ func main() {
 
 	cfg := config.GetConfig()
 
-	rm := c.NewRedisManager(cfg)
-	cm := c.NewConnectionManager(rm)
+	cm := c.NewConnectionManager()
 	mgmtMux := mux.NewRouter()
 	mgmtServer := api.NewManagementServer(cm, mgmtMux, cfg)
 	mgmtServer.Routes()

--- a/cmd/job_receiver/main.go
+++ b/cmd/job_receiver/main.go
@@ -23,7 +23,8 @@ func main() {
 
 	cfg := config.GetConfig()
 
-	cm := c.NewConnectionManager()
+	var cm c.ConnectionLocator
+	cm = &c.RedisConnectionLocator{}
 	mgmtMux := mux.NewRouter()
 	mgmtServer := api.NewManagementServer(cm, mgmtMux, cfg)
 	mgmtServer.Routes()

--- a/internal/controller/api/job_receiver.go
+++ b/internal/controller/api/job_receiver.go
@@ -16,13 +16,13 @@ import (
 )
 
 type JobReceiver struct {
-	connectionMgr controller.ConnectionManager
+	connectionMgr controller.ConnectionLocator
 	router        *mux.Router
 	producer      *kafka.Writer
 	config        *config.Config
 }
 
-func NewJobReceiver(cm controller.ConnectionManager, r *mux.Router, kw *kafka.Writer, cfg *config.Config) *JobReceiver {
+func NewJobReceiver(cm controller.ConnectionLocator, r *mux.Router, kw *kafka.Writer, cfg *config.Config) *JobReceiver {
 	return &JobReceiver{
 		connectionMgr: cm,
 		router:        r,

--- a/internal/controller/api/management.go
+++ b/internal/controller/api/management.go
@@ -21,12 +21,12 @@ const (
 )
 
 type ManagementServer struct {
-	connectionMgr controller.ConnectionManager
+	connectionMgr controller.ConnectionLocator
 	router        *mux.Router
 	config        *config.Config
 }
 
-func NewManagementServer(cm controller.ConnectionManager, r *mux.Router, cfg *config.Config) *ManagementServer {
+func NewManagementServer(cm controller.ConnectionLocator, r *mux.Router, cfg *config.Config) *ManagementServer {
 	return &ManagementServer{
 		connectionMgr: cm,
 		router:        r,

--- a/internal/controller/connection_manager.go
+++ b/internal/controller/connection_manager.go
@@ -24,9 +24,12 @@ func (d DuplicateConnectionError) Error() string {
 	return "duplicate node id"
 }
 
-type ConnectionManager interface {
+type ConnectionRegistrar interface {
 	Register(account string, node_id string, client Receptor) error
 	Unregister(account string, node_id string)
+}
+
+type ConnectionLocator interface {
 	GetConnection(account string, node_id string) Receptor
 	GetConnectionsByAccount(account string) map[string]Receptor
 	GetAllConnections() map[string]map[string]Receptor
@@ -37,7 +40,7 @@ type LocalConnectionManager struct {
 	sync.RWMutex
 }
 
-func NewConnectionManager() ConnectionManager {
+func NewLocalConnectionManager() *LocalConnectionManager {
 	return &LocalConnectionManager{
 		connections: make(map[string]map[string]Receptor),
 	}

--- a/internal/controller/disconnect_handler.go
+++ b/internal/controller/disconnect_handler.go
@@ -11,7 +11,7 @@ import (
 type DisconnectHandler struct {
 	AccountNumber string
 	NodeID        string
-	ConnectionMgr ConnectionManager
+	ConnectionMgr ConnectionRegistrar
 	Logger        *logrus.Entry
 }
 

--- a/internal/controller/gateway_connection_manager.go
+++ b/internal/controller/gateway_connection_manager.go
@@ -1,0 +1,60 @@
+package controller
+
+import (
+	"github.com/RedHatInsights/platform-receptor-controller/internal/platform/logger"
+
+	"github.com/sirupsen/logrus"
+)
+
+type GatewayConnectionManager struct {
+	rm                     RedisInterface
+	localConnectionManager ConnectionManager
+}
+
+func NewGatewayConnectionManager(rm RedisInterface, cm ConnectionManager) ConnectionManager {
+	return &GatewayConnectionManager{
+		rm:                     rm,
+		localConnectionManager: cm,
+	}
+}
+
+func (rcm *GatewayConnectionManager) Register(account string, node_id string, client Receptor) error {
+	if rcm.rm.Exists(account, node_id) { // checking connection globally
+		logger := logger.Log.WithFields(logrus.Fields{"account": account, "node_id": node_id})
+		logger.Warn("Attempting to register duplicate connection")
+		metrics.duplicateConnectionCounter.Inc()
+		return DuplicateConnectionError{}
+	}
+
+	err := rcm.rm.Register(account, node_id)
+	if err != nil {
+		return err
+	}
+
+	err = rcm.localConnectionManager.Register(account, node_id, client)
+	if err != nil {
+		rcm.Unregister(account, node_id)
+		return err
+	}
+
+	logger.Log.Printf("Registered a connection (%s, %s)", account, node_id)
+	return nil
+}
+
+func (rcm *GatewayConnectionManager) Unregister(account string, node_id string) {
+	rcm.rm.Unregister(account, node_id)
+	rcm.localConnectionManager.Unregister(account, node_id)
+	logger.Log.Printf("Unregistered a connection (%s, %s)", account, node_id)
+}
+
+func (rcm *GatewayConnectionManager) GetConnection(account string, node_id string) Receptor {
+	return rcm.localConnectionManager.GetConnection(account, node_id)
+}
+
+func (rcm *GatewayConnectionManager) GetConnectionsByAccount(account string) map[string]Receptor {
+	return rcm.localConnectionManager.GetConnectionsByAccount(account)
+}
+
+func (rcm *GatewayConnectionManager) GetAllConnections() map[string]map[string]Receptor {
+	return rcm.localConnectionManager.GetAllConnections()
+}

--- a/internal/controller/handshake_handler.go
+++ b/internal/controller/handshake_handler.go
@@ -16,7 +16,7 @@ type HandshakeHandler struct {
 	Transport                *Transport
 	ReceptorServiceFactory   *ReceptorServiceFactory
 	ResponseReactor          ResponseReactor
-	ConnectionMgr            ConnectionManager
+	ConnectionMgr            ConnectionRegistrar
 	MessageDispatcherFactory *MessageDispatcherFactory
 	Logger                   *logrus.Entry
 }

--- a/internal/controller/redis_connection_locator.go
+++ b/internal/controller/redis_connection_locator.go
@@ -1,0 +1,26 @@
+package controller
+
+import (
+//	"github.com/RedHatInsights/platform-receptor-controller/internal/platform/logger"
+//	"github.com/sirupsen/logrus"
+)
+
+type RedisConnectionLocator struct {
+}
+
+func (cm *RedisConnectionLocator) GetConnection(account string, node_id string) Receptor {
+	var conn Receptor
+	return conn
+}
+
+func (cm *RedisConnectionLocator) GetConnectionsByAccount(account string) map[string]Receptor {
+	connectionsPerAccount := make(map[string]Receptor)
+
+	return connectionsPerAccount
+}
+
+func (cm *RedisConnectionLocator) GetAllConnections() map[string]map[string]Receptor {
+	connectionMap := make(map[string]map[string]Receptor)
+
+	return connectionMap
+}

--- a/internal/controller/ws/handler.go
+++ b/internal/controller/ws/handler.go
@@ -17,7 +17,7 @@ import (
 )
 
 type ReceptorController struct {
-	connectionMgr            controller.ConnectionManager
+	connectionMgr            controller.ConnectionRegistrar
 	router                   *mux.Router
 	config                   *config.Config
 	responseReactorFactory   *controller.ResponseReactorFactory
@@ -25,7 +25,7 @@ type ReceptorController struct {
 	receptorServiceFactory   *controller.ReceptorServiceFactory
 }
 
-func NewReceptorController(cfg *config.Config, cm controller.ConnectionManager, r *mux.Router, rd *controller.ResponseReactorFactory, md *controller.MessageDispatcherFactory, rs *controller.ReceptorServiceFactory) *ReceptorController {
+func NewReceptorController(cfg *config.Config, cm controller.ConnectionRegistrar, r *mux.Router, rd *controller.ResponseReactorFactory, md *controller.MessageDispatcherFactory, rs *controller.ReceptorServiceFactory) *ReceptorController {
 	return &ReceptorController{
 		connectionMgr:            cm,
 		router:                   r,


### PR DESCRIPTION
This PR pulls the register/unregister with logic into a decorator ConnectionManager object that wraps the local ConnectionManager.  It also splits the ConnectionManager interface into a ConnectionRegistrar and ConnectionLocator.  The LocalConnectionManager implements both the ConnectionRegistrar and ConnectionLocator interfaces.