### PR TITLE
Fix the existing tests

### DIFF
--- a/internal/controller/api/job_receiver_test.go
+++ b/internal/controller/api/job_receiver_test.go
@@ -58,7 +58,7 @@ var _ = Describe("JobReceiver", func() {
 
 	BeforeEach(func() {
 		apiMux := mux.NewRouter()
-		cm := controller.NewConnectionManager(&MockRedisManager{exists: false})
+		cm := controller.NewLocalConnectionManager()
 		mc := MockClient{}
 		cm.Register("1234", "345", mc)
 		cfg := config.GetConfig()

--- a/internal/controller/api/management_test.go
+++ b/internal/controller/api/management_test.go
@@ -56,14 +56,14 @@ func createConnectionStatusPostBody(account_number string, node_id string) io.Re
 var _ = Describe("Management", func() {
 
 	var (
-		cm                  controller.ConnectionManager
+		cm                  *controller.LocalConnectionManager
 		ms                  *ManagementServer
 		validIdentityHeader string
 	)
 
 	BeforeEach(func() {
 		apiMux := mux.NewRouter()
-		cm = controller.NewConnectionManager(&MockRedisManager{exists: false})
+		cm = controller.NewLocalConnectionManager()
 		mc := MockClient{}
 		cm.Register(CONNECTED_ACCOUNT_NUMBER, CONNECTED_NODE_ID, mc)
 		cfg := config.GetConfig()

--- a/internal/controller/ws/handler_test.go
+++ b/internal/controller/ws/handler_test.go
@@ -43,21 +43,6 @@ func writeSocket(c *websocket.Conn, message protocol.Message) error {
 	return err
 }
 
-type MockRedisManager struct {
-	exists bool
-}
-
-func (mrm *MockRedisManager) Exists(account, node_id string) bool {
-	return mrm.exists
-}
-
-func (mrm *MockRedisManager) Register(account, node_id string) error {
-	return nil
-}
-
-func (mrm *MockRedisManager) Unregister(account, node_id string) {
-}
-
 func leaks() error {
 	return goleak.Find(goleak.IgnoreTopFunction("github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).registerForInterrupts"))
 }
@@ -66,7 +51,7 @@ var _ = Describe("WsController", func() {
 	var (
 		identity string
 		wsMux    *mux.Router
-		cm       controller.ConnectionManager
+		cr       controller.ConnectionRegistrar
 		cfg      *config.Config
 		rc       *ReceptorController
 		kw       *kafka.Writer
@@ -77,7 +62,7 @@ var _ = Describe("WsController", func() {
 	BeforeEach(func() {
 		wsMux = mux.NewRouter()
 		cfg = config.GetConfig()
-		cm = controller.NewConnectionManager(&MockRedisManager{exists: false})
+		cr = controller.NewLocalConnectionManager()
 		kc := &queue.ConsumerConfig{
 			Brokers:        cfg.KafkaBrokers,
 			Topic:          cfg.KafkaJobsTopic,
@@ -91,7 +76,7 @@ var _ = Describe("WsController", func() {
 		})
 		rd := controller.NewResponseReactorFactory()
 		rs := controller.NewReceptorServiceFactory(kw, cfg)
-		rc = NewReceptorController(cfg, cm, wsMux, rd, md, rs)
+		rc = NewReceptorController(cfg, cr, wsMux, rd, md, rs)
 		rc.Routes()
 
 		d = wstest.NewDialer(rc.router)


### PR DESCRIPTION
Fix the tests that I broke when splitting the ConnectionManager interface and implementing the redist ConnectionManager decorator