### PR TITLE
Adding a simple kafka reader util to the deployed image to help troubleshoot kafka message dispatching

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -32,6 +32,7 @@ echo "---> Copying binaries into place..."
 mkdir -p $INSTALL_DIR
 cp gateway $INSTALL_DIR
 cp job-receiver $INSTALL_DIR
+cp response_consumer $INSTALL_DIR
 
 echo "---> Copying openapi spec into place..."
 mkdir -p $API_SPEC_DIR

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ COVERAGE_HTML=coverage.html
 build:
 	go build -o $(GATEWAY_BINARY) cmd/gateway/main.go
 	go build -o $(JOB_RECEIVER_BINARY) cmd/job_receiver/main.go
+	go build -o response_consumer cmd/response_consumer/main.go
 
 deps:
 	go get -u golang.org/x/lint/golint

--- a/cmd/response_consumer/main.go
+++ b/cmd/response_consumer/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/RedHatInsights/platform-receptor-controller/internal/config"
+
+	"github.com/google/uuid"
+	kafka "github.com/segmentio/kafka-go"
+)
+
+func main() {
+	cfg := config.GetConfig()
+
+	groupID, err := uuid.NewRandom()
+	if err != nil {
+		fmt.Println("Unable to generate random uuid:", err)
+		return
+	}
+
+	kafkaConfig := kafka.ReaderConfig{
+		Brokers:     cfg.KafkaBrokers,
+		Topic:       cfg.KafkaResponsesTopic,
+		GroupID:     groupID.String(),
+		StartOffset: cfg.KafkaConsumerOffset,
+	}
+
+	kafkaReader := kafka.NewReader(kafkaConfig)
+
+	fmt.Println("Kafka consumer config: ", kafkaReader.Config())
+
+	for {
+		m, err := kafkaReader.ReadMessage(context.Background())
+		if err != nil {
+			fmt.Println("Got an error:", err)
+			break
+		}
+		fmt.Printf("message at offset %d: %s = %s\n", m.Offset, string(m.Key), string(m.Value))
+	}
+
+	kafkaReader.Close()
+}


### PR DESCRIPTION
Right now there is not an easy way to confirm that the messages are getting sent to kafka in the openshift environments.  This PR adds a simple kafka reader util that will listen on the responses topic and print out the responses it receives.