### PR TITLE
Improve the Receptor interface

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -32,7 +32,7 @@ func closeConnections(cm c.ConnectionManager, wg *sync.WaitGroup, timeout time.D
 	connections := cm.GetAllConnections()
 	for _, conn := range connections {
 		for _, client := range conn {
-			client.Close()
+			client.Close(context.TODO())
 		}
 	}
 	time.Sleep(timeout)

--- a/internal/controller/api/job_receiver_test.go
+++ b/internal/controller/api/job_receiver_test.go
@@ -38,11 +38,12 @@ func (mc MockClient) Ping(context.Context, string, string, []string) (interface{
 	return nil, nil
 }
 
-func (mc MockClient) Close() {
+func (mc MockClient) Close(context.Context) error {
+	return nil
 }
 
-func (mc MockClient) GetCapabilities() interface{} {
-	return struct{}{}
+func (mc MockClient) GetCapabilities(context.Context) (interface{}, error) {
+	return struct{}{}, nil
 }
 
 func init() {

--- a/internal/controller/api/management.go
+++ b/internal/controller/api/management.go
@@ -101,7 +101,7 @@ func (s *ManagementServer) handleDisconnect() http.HandlerFunc {
 		logger.Infof("Attempting to disconnect account:%s - node id:%s",
 			connID.Account, connID.NodeID)
 
-		client.Close()
+		client.Close(req.Context())
 
 		writeJSONResponse(w, http.StatusOK, struct{}{})
 	}
@@ -137,7 +137,11 @@ func (s *ManagementServer) handleConnectionStatus() http.HandlerFunc {
 		client := s.connectionMgr.GetConnection(connID.Account, connID.NodeID)
 		if client != nil {
 			connectionStatus.Status = CONNECTED_STATUS
-			connectionStatus.Capabilities = client.GetCapabilities()
+			capabilities, err := client.GetCapabilities(req.Context())
+			if err != nil {
+				logger.Infof("Unable to retrieve the capabilities of node %s", connID.NodeID)
+			}
+			connectionStatus.Capabilities = capabilities
 		} else {
 			connectionStatus.Status = DISCONNECTED_STATUS
 		}

--- a/internal/controller/connection_manager.go
+++ b/internal/controller/connection_manager.go
@@ -13,8 +13,8 @@ import (
 type Receptor interface {
 	SendMessage(context.Context, string, string, []string, interface{}, string) (*uuid.UUID, error)
 	Ping(context.Context, string, string, []string) (interface{}, error)
-	Close()
-	GetCapabilities() interface{}
+	Close(context.Context) error
+	GetCapabilities(context.Context) (interface{}, error)
 }
 
 type DuplicateConnectionError struct {

--- a/internal/controller/connection_manager_test.go
+++ b/internal/controller/connection_manager_test.go
@@ -27,11 +27,12 @@ func (mr *MockReceptor) Ping(context.Context, string, string, []string) (interfa
 	return nil, nil
 }
 
-func (mr *MockReceptor) Close() {
+func (mr *MockReceptor) Close(context.Context) error {
+	return nil
 }
 
-func (mr *MockReceptor) GetCapabilities() interface{} {
-	return nil
+func (mr *MockReceptor) GetCapabilities(context.Context) (interface{}, error) {
+	return nil, nil
 }
 
 func TestCheckForConnectionThatDoesNotExist(t *testing.T) {

--- a/internal/controller/receptor.go
+++ b/internal/controller/receptor.go
@@ -281,28 +281,29 @@ func (r *ReceptorService) DispatchResponse(payloadMessage *protocol.PayloadMessa
 
 }
 
-func (r *ReceptorService) Close() {
+func (r *ReceptorService) Close(ctx context.Context) error {
 	r.Transport.Cancel()
+	return nil
 }
 
-func (r *ReceptorService) GetCapabilities() interface{} {
+func (r *ReceptorService) GetCapabilities(ctx context.Context) (interface{}, error) {
 	emptyCapabilities := struct{}{}
 
 	if r.Metadata == nil {
-		return emptyCapabilities
+		return emptyCapabilities, nil
 	}
 
 	metadata, ok := r.Metadata.(map[string]interface{})
 	if ok != true {
-		return emptyCapabilities
+		return emptyCapabilities, nil
 	}
 
 	capabilities, exist := metadata["capabilities"]
 	if exist != true {
-		return emptyCapabilities
+		return emptyCapabilities, nil
 	}
 
-	return capabilities
+	return capabilities, nil
 }
 
 type DispatcherTable struct {


### PR DESCRIPTION
Trying to improve the Receptor interface by adding the ability to add errors to all the calls and adding the ability to pass a context to all the calls

TODO:
- [ ] more testing
