### PR TITLE
Adding tests for gateway conn manager. Renaming existing tests.

### DIFF
--- a/internal/controller/api/http_proxy_connection_manager_test.go
+++ b/internal/controller/api/http_proxy_connection_manager_test.go
@@ -1,0 +1,163 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/RedHatInsights/platform-receptor-controller/internal/config"
+	"github.com/RedHatInsights/platform-receptor-controller/internal/controller"
+
+	"github.com/alicebob/miniredis"
+	"github.com/go-playground/assert/v2"
+	"github.com/go-redis/redis"
+)
+
+func newTestRedisClient(addr string) *redis.Client {
+	return redis.NewClient(&redis.Options{
+		Addr:     addr,
+		Password: "",
+		DB:       0,
+	})
+}
+
+func TestGetConnection(t *testing.T) {
+	s, _ := miniredis.Run()
+	defer s.Close()
+
+	c := newTestRedisClient(s.Addr())
+
+	locator := &RedisConnectionLocator{
+		Client: c,
+		Cfg:    config.GetConfig(),
+	}
+
+	_ = controller.RegisterWithRedis(locator.Client, "01", "node-a", "localhost")
+
+	tests := []struct {
+		account      string
+		nodeID       string
+		expectedConn controller.Receptor
+	}{
+		{
+			account: "01",
+			nodeID:  "node-a",
+			expectedConn: &ReceptorHttpProxy{
+				Hostname:      "localhost",
+				AccountNumber: "01",
+				NodeID:        "node-a",
+				Config:        locator.Cfg,
+			},
+		},
+		{
+			account:      "01",
+			nodeID:       "not-found",
+			expectedConn: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		conn := locator.GetConnection(tc.account, tc.nodeID)
+		assert.Equal(t, conn, tc.expectedConn)
+	}
+}
+
+func TestGetConnectionsByAccount(t *testing.T) {
+	s, _ := miniredis.Run()
+	defer s.Close()
+
+	c := newTestRedisClient(s.Addr())
+
+	locator := &RedisConnectionLocator{
+		Client: c,
+		Cfg:    config.GetConfig(),
+	}
+
+	_ = controller.RegisterWithRedis(c, "01", "node-a", "localhost")
+	_ = controller.RegisterWithRedis(c, "01", "node-b", "localhost")
+	_ = controller.RegisterWithRedis(c, "02", "node-c", "localhost")
+
+	tests := []struct {
+		account       string
+		expectedConns map[string]controller.Receptor
+	}{
+		{
+			account: "01",
+			expectedConns: map[string]controller.Receptor{
+				"node-a": &ReceptorHttpProxy{
+					Hostname:      "localhost",
+					AccountNumber: "01",
+					NodeID:        "node-a",
+					Config:        locator.Cfg,
+				},
+				"node-b": &ReceptorHttpProxy{
+					Hostname:      "localhost",
+					AccountNumber: "01",
+					NodeID:        "node-b",
+					Config:        locator.Cfg,
+				},
+			},
+		},
+		{
+			account: "02",
+			expectedConns: map[string]controller.Receptor{
+				"node-c": &ReceptorHttpProxy{
+					Hostname:      "localhost",
+					AccountNumber: "02",
+					NodeID:        "node-c",
+					Config:        locator.Cfg,
+				},
+			},
+		},
+		{
+			account:       "not-found",
+			expectedConns: map[string]controller.Receptor{},
+		},
+	}
+
+	for _, tc := range tests {
+		res := locator.GetConnectionsByAccount(tc.account)
+		assert.Equal(t, res, tc.expectedConns)
+	}
+}
+
+func TestGetAllConnections(t *testing.T) {
+	s, _ := miniredis.Run()
+	defer s.Close()
+
+	c := newTestRedisClient(s.Addr())
+
+	locator := &RedisConnectionLocator{
+		Client: c,
+		Cfg:    config.GetConfig(),
+	}
+
+	_ = controller.RegisterWithRedis(c, "01", "node-a", "localhost")
+	_ = controller.RegisterWithRedis(c, "01", "node-b", "localhost")
+	_ = controller.RegisterWithRedis(c, "02", "node-c", "localhost")
+
+	res := locator.GetAllConnections()
+
+	assert.Equal(t, map[string]map[string]controller.Receptor{
+		"01": {
+			"node-a": &ReceptorHttpProxy{
+				Hostname:      "localhost",
+				AccountNumber: "01",
+				NodeID:        "node-a",
+				Config:        locator.Cfg,
+			},
+			"node-b": &ReceptorHttpProxy{
+				Hostname:      "localhost",
+				AccountNumber: "01",
+				NodeID:        "node-b",
+				Config:        locator.Cfg,
+			},
+		},
+		"02": {
+			"node-c": &ReceptorHttpProxy{
+				Hostname:      "localhost",
+				AccountNumber: "02",
+				NodeID:        "node-c",
+				Config:        locator.Cfg,
+			},
+		},
+	}, res)
+}

--- a/internal/controller/connection_manager_test.go
+++ b/internal/controller/connection_manager_test.go
@@ -35,7 +35,7 @@ func (mr *MockReceptor) GetCapabilities(context.Context) (interface{}, error) {
 	return nil, nil
 }
 
-func TestCheckForConnectionThatDoesNotExist(t *testing.T) {
+func TestCheckForLocalConnectionThatDoesNotExist(t *testing.T) {
 	var cl ConnectionLocator
 	cl = NewLocalConnectionManager()
 	receptorConnection := cl.GetConnection("not gonna find me", "or me")
@@ -44,7 +44,7 @@ func TestCheckForConnectionThatDoesNotExist(t *testing.T) {
 	}
 }
 
-func TestCheckForConnectionThatDoesNotExistButAccountExists(t *testing.T) {
+func TestCheckForLocalConnectionThatDoesNotExistButAccountExists(t *testing.T) {
 	registeredAccount := "123"
 	lcm := NewLocalConnectionManager()
 	lcm.Register(registeredAccount, "456", &MockReceptor{})
@@ -54,7 +54,7 @@ func TestCheckForConnectionThatDoesNotExistButAccountExists(t *testing.T) {
 	}
 }
 
-func TestCheckForConnectionThatDoesExist(t *testing.T) {
+func TestCheckForLocalConnectionThatDoesExist(t *testing.T) {
 	mockReceptor := &MockReceptor{}
 	cm := NewLocalConnectionManager()
 	cm.Register("123", "456", mockReceptor)
@@ -68,7 +68,7 @@ func TestCheckForConnectionThatDoesExist(t *testing.T) {
 	}
 }
 
-func TestRegisterAndUnregisterMultipleConnectionsPerAccount(t *testing.T) {
+func TestRegisterAndUnregisterMultipleLocalConnectionsPerAccount(t *testing.T) {
 	accountNumber := "0000001"
 	var testReceptors = []struct {
 		account  string
@@ -97,12 +97,12 @@ func TestRegisterAndUnregisterMultipleConnectionsPerAccount(t *testing.T) {
 	}
 }
 
-func TestUnregisterConnectionThatDoesNotExist(t *testing.T) {
+func TestUnregisterLocalConnectionThatDoesNotExist(t *testing.T) {
 	cm := NewLocalConnectionManager()
 	cm.Unregister("not gonna find me", "or me")
 }
 
-func TestGetConnectionsByAccount(t *testing.T) {
+func TestGetLocalConnectionsByAccount(t *testing.T) {
 	accountNumber := "0000001"
 	var testReceptors = []struct {
 		account  string
@@ -123,7 +123,7 @@ func TestGetConnectionsByAccount(t *testing.T) {
 	}
 }
 
-func TestGetConnectionsByAccountWithNoRegisteredReceptors(t *testing.T) {
+func TestGetLocalConnectionsByAccountWithNoRegisteredReceptors(t *testing.T) {
 	cm := NewLocalConnectionManager()
 	receptorMap := cm.GetConnectionsByAccount("0000001")
 	if len(receptorMap) != 0 {
@@ -131,7 +131,7 @@ func TestGetConnectionsByAccountWithNoRegisteredReceptors(t *testing.T) {
 	}
 }
 
-func TestGetAllConnections(t *testing.T) {
+func TestGetAllLocalConnections(t *testing.T) {
 
 	var testReceptors = map[string]map[string]Receptor{
 		"0000001": {"node-a": &MockReceptor{},
@@ -154,7 +154,7 @@ func TestGetAllConnections(t *testing.T) {
 	}
 }
 
-func TestGetAllConnectionsWithNoRegisteredReceptors(t *testing.T) {
+func TestGetAllLocalConnectionsWithNoRegisteredReceptors(t *testing.T) {
 	cm := NewLocalConnectionManager()
 	receptorMap := cm.GetAllConnections()
 	if len(receptorMap) != 0 {
@@ -162,7 +162,7 @@ func TestGetAllConnectionsWithNoRegisteredReceptors(t *testing.T) {
 	}
 }
 
-func TestRegisterConnectionsWithDuplicateNodeIDs(t *testing.T) {
+func TestRegisterLocalConnectionsWithDuplicateNodeIDs(t *testing.T) {
 	accountNumber := "123"
 	nodeID := "456"
 	expectedReceptorObj := new(MockReceptor)

--- a/internal/controller/gateway_connection_manager_test.go
+++ b/internal/controller/gateway_connection_manager_test.go
@@ -1,0 +1,182 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/RedHatInsights/platform-receptor-controller/internal/platform/utils"
+	"github.com/go-playground/assert/v2"
+
+	"github.com/RedHatInsights/platform-receptor-controller/internal/platform/logger"
+	"github.com/alicebob/miniredis"
+)
+
+func init() {
+	logger.InitLogger()
+}
+
+var hostname string = utils.GetHostname()
+
+func TestRegisterWithGatewayConnectionManager(t *testing.T) {
+	s, _ := miniredis.Run()
+	defer s.Close()
+
+	c := newTestRedisClient(s.Addr())
+	lcm := NewLocalConnectionManager()
+
+	gcm := NewGatewayConnectionRegistrar(c, lcm, hostname)
+
+	tests := []struct {
+		account string
+		nodeID  string
+		client  Receptor
+		err     error
+	}{
+		{
+			account: "01",
+			nodeID:  "node-a",
+			client:  &MockReceptor{NodeID: "node-a"},
+			err:     nil,
+		},
+		{
+			account: "01",
+			nodeID:  "node-b",
+			client:  &MockReceptor{NodeID: "node-b"},
+			err:     nil,
+		},
+		{
+			account: "02",
+			nodeID:  "node-a",
+			client:  &MockReceptor{NodeID: "node-a"},
+			err:     nil,
+		},
+	}
+
+	for _, tc := range tests {
+		got := gcm.Register(tc.account, tc.nodeID, tc.client)
+		if got != tc.err {
+			t.Fatalf("expected: %v, got: %v", tc.err, got)
+		}
+		assert.Equal(t, c.Get(tc.account+":"+tc.nodeID).Val(), hostname)     // check redis
+		assert.Equal(t, tc.client, lcm.GetConnection(tc.account, tc.nodeID)) // check local connections
+	}
+}
+
+func TestRegisterDuplicateWithGatewayConnectionManager(t *testing.T) {
+	s, _ := miniredis.Run()
+	defer s.Close()
+
+	c := newTestRedisClient(s.Addr())
+	lcm := NewLocalConnectionManager()
+
+	gcm := NewGatewayConnectionRegistrar(c, lcm, hostname)
+
+	_ = RegisterWithRedis(c, "01", "node-c", hostname)
+	lcm.Register("01", "node-d", &MockReceptor{NodeID: "node-d"})
+
+	tests := []struct {
+		account        string
+		nodeID         string
+		client         Receptor
+		expectedClient Receptor
+		expectedHost   string
+		err            error
+	}{
+		{
+			account:        "01",
+			nodeID:         "node-a",
+			client:         &MockReceptor{NodeID: "node-a"},
+			expectedClient: &MockReceptor{NodeID: "node-a"},
+			expectedHost:   hostname,
+			err:            nil,
+		},
+		{
+			account:        "01",
+			nodeID:         "node-b",
+			client:         &MockReceptor{NodeID: "node-b"},
+			expectedClient: &MockReceptor{NodeID: "node-b"},
+			expectedHost:   hostname,
+			err:            nil,
+		},
+		// connection registered in redis but not locally
+		{
+			account:        "01",
+			nodeID:         "node-c",
+			client:         &MockReceptor{NodeID: "node-c"},
+			expectedClient: nil,
+			expectedHost:   hostname,
+			err:            DuplicateConnectionError{},
+		},
+		// connection registered locally but not in redis
+		{
+			account:        "01",
+			nodeID:         "node-d",
+			client:         &MockReceptor{NodeID: "node-d"},
+			expectedClient: nil,
+			expectedHost:   "",
+			err:            DuplicateConnectionError{},
+		},
+	}
+
+	for _, tc := range tests {
+		got := gcm.Register(tc.account, tc.nodeID, tc.client)
+		if got != tc.err {
+			t.Fatalf("expected: %v, got: %v", tc.err, got)
+		}
+		assert.Equal(t, c.Get(tc.account+":"+tc.nodeID).Val(), tc.expectedHost)
+		assert.Equal(t, lcm.GetConnection(tc.account, tc.nodeID), tc.expectedClient)
+	}
+}
+
+func TestUnregisterWithGatewayConnectionManager(t *testing.T) {
+	s, _ := miniredis.Run()
+	defer s.Close()
+
+	c := newTestRedisClient(s.Addr())
+	lcm := NewLocalConnectionManager()
+
+	gcm := NewGatewayConnectionRegistrar(c, lcm, hostname)
+
+	_ = gcm.Register("01", "node-a", &MockReceptor{NodeID: "node-a"})
+	_ = gcm.Register("01", "node-b", &MockReceptor{NodeID: "node-b"})
+	_ = gcm.Register("01", "node-c", &MockReceptor{NodeID: "node-c"})
+	_ = gcm.Register("01", "node-d", &MockReceptor{NodeID: "node-d"})
+
+	tests := []struct {
+		account string
+		nodeID  string
+		client  Receptor
+		err     error
+	}{
+		{
+			account: "01",
+			nodeID:  "node-a",
+			client:  &MockReceptor{NodeID: "node-a"},
+			err:     nil,
+		},
+		{
+			account: "01",
+			nodeID:  "node-b",
+			client:  &MockReceptor{NodeID: "node-b"},
+			err:     nil,
+		},
+		{
+			account: "01",
+			nodeID:  "node-c",
+			client:  &MockReceptor{NodeID: "node-c"},
+			err:     nil,
+		},
+	}
+
+	for _, tc := range tests {
+		assert.Equal(t, c.Get(tc.account+":"+tc.nodeID).Val(), hostname)     // check redis
+		assert.Equal(t, lcm.GetConnection(tc.account, tc.nodeID), tc.client) // check local connections
+
+		gcm.Unregister(tc.account, tc.nodeID)
+
+		assert.Equal(t, c.Get(tc.account+":"+tc.nodeID).Val(), "")
+		assert.Equal(t, lcm.GetConnection(tc.account, tc.nodeID), nil)
+	}
+
+	assert.Equal(t, c.Get("01:node-d").Val(), hostname)
+	assert.Equal(t, lcm.GetConnection("01", "node-d"), &MockReceptor{NodeID: "node-d"})
+}


### PR DESCRIPTION
- Added "Local" to test names in connection_manager_test.go 
- Added new file specifically for testing the gateway connection manager (currently just Register/Unregister)

@dehort Pretty simple for now since I just wanted to get _something_ in place for gateway tests. Definitely let me know if you want to see any additional cases around the Register and Unregister functions for the gateway connection manager. The mock receptor client and redis client are both defined elsewhere in the package. I think we should move towards grouping these test mocks/functions into a separate package.