### PR TITLE
Removing the kafka producer instance from the job_receiver

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -97,7 +97,7 @@ func main() {
 	mgmtServer := api.NewManagementServer(localCM, apiMux, cfg)
 	mgmtServer.Routes()
 
-	jr := api.NewJobReceiver(localCM, apiMux, kw, cfg)
+	jr := api.NewJobReceiver(localCM, apiMux, cfg)
 	jr.Routes()
 
 	apiMux.Handle("/metrics", promhttp.Handler())

--- a/cmd/job_receiver/main.go
+++ b/cmd/job_receiver/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/RedHatInsights/platform-receptor-controller/internal/controller/api"
 
 	"github.com/RedHatInsights/platform-receptor-controller/internal/platform/logger"
-	"github.com/RedHatInsights/platform-receptor-controller/internal/platform/queue"
 	"github.com/redhatinsights/platform-go-middlewares/request_id"
 
 	"github.com/go-redis/redis"
@@ -83,12 +82,7 @@ func main() {
 	mgmtServer := api.NewManagementServer(connectionLocator, apiMux, cfg)
 	mgmtServer.Routes()
 
-	kw := queue.StartProducer(&queue.ProducerConfig{
-		Brokers: cfg.KafkaBrokers,
-		Topic:   cfg.KafkaResponsesTopic,
-	})
-
-	jr := api.NewJobReceiver(connectionLocator, apiMux, kw, cfg)
+	jr := api.NewJobReceiver(connectionLocator, apiMux, cfg)
 	jr.Routes()
 
 	go func() {

--- a/internal/controller/api/job_receiver.go
+++ b/internal/controller/api/job_receiver.go
@@ -10,22 +10,19 @@ import (
 	"github.com/redhatinsights/platform-go-middlewares/request_id"
 
 	"github.com/gorilla/mux"
-	kafka "github.com/segmentio/kafka-go"
 	"github.com/sirupsen/logrus"
 )
 
 type JobReceiver struct {
 	connectionMgr controller.ConnectionLocator
 	router        *mux.Router
-	producer      *kafka.Writer
 	config        *config.Config
 }
 
-func NewJobReceiver(cm controller.ConnectionLocator, r *mux.Router, kw *kafka.Writer, cfg *config.Config) *JobReceiver {
+func NewJobReceiver(cm controller.ConnectionLocator, r *mux.Router, cfg *config.Config) *JobReceiver {
 	return &JobReceiver{
 		connectionMgr: cm,
 		router:        r,
-		producer:      kw,
 		config:        cfg,
 	}
 }

--- a/internal/controller/api/job_receiver_test.go
+++ b/internal/controller/api/job_receiver_test.go
@@ -73,7 +73,7 @@ var _ = Describe("JobReceiver", func() {
 		errorMC := MockClient{returnAnError: true}
 		cm.Register("1234", "error-client", errorMC)
 		cfg := config.GetConfig()
-		jr = NewJobReceiver(cm, apiMux, nil, cfg)
+		jr = NewJobReceiver(cm, apiMux, cfg)
 		jr.Routes()
 
 		identity := `{ "identity": {"account_number": "540155", "type": "User", "internal": { "org_id": "1979710" } } }`

--- a/internal/controller/api/management.go
+++ b/internal/controller/api/management.go
@@ -147,6 +147,9 @@ func (s *ManagementServer) handleConnectionStatus() http.HandlerFunc {
 			connectionStatus.Status = DISCONNECTED_STATUS
 		}
 
+		logger.Infof("Connection status for account:%s - node id:%s => %s\n",
+			connID.Account, connID.NodeID, connectionStatus.Status)
+
 		writeJSONResponse(w, http.StatusOK, connectionStatus)
 	}
 }

--- a/internal/controller/receptor.go
+++ b/internal/controller/receptor.go
@@ -282,6 +282,7 @@ func (r *ReceptorService) DispatchResponse(payloadMessage *protocol.PayloadMessa
 }
 
 func (r *ReceptorService) Close(ctx context.Context) error {
+	r.logger.Info("Closing connection")
 	r.Transport.Cancel()
 	return nil
 }


### PR DESCRIPTION
For now, I'm going to remove the kafka producer from the job_reciever object.  We might add it back in later, but I think at that point we'll modify the receptor proxy object to use the kafka producer...so the job_receiver will not have a direct dependency on the kafka producer.