### PR TITLE
Disable the ping duration metric for now

### DIFF
--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -3,11 +3,9 @@ package controller
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"time"
 )
 
 type Metrics struct {
-	pingElapsed                          *prometheus.HistogramVec
 	duplicateConnectionCounter           prometheus.Counter
 	responseKafkaWriterGoRoutineGauge    prometheus.Gauge
 	responseKafkaWriterFailureCounter    prometheus.Counter
@@ -17,13 +15,6 @@ type Metrics struct {
 
 func NewMetrics() *Metrics {
 	metrics := new(Metrics)
-
-	metrics.pingElapsed = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "receptor_controller_ping_seconds",
-		Help: "Number of seconds spent waiting on a synchronous ping",
-	},
-		[]string{"account", "recipient"},
-	)
 
 	metrics.duplicateConnectionCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "receptor_controller_duplicate_connection_count",
@@ -51,23 +42,6 @@ func NewMetrics() *Metrics {
 	})
 
 	return metrics
-}
-
-type DurationRecorder struct {
-	elapsed   *prometheus.HistogramVec
-	labels    prometheus.Labels
-	startTime time.Time
-}
-
-func (dr *DurationRecorder) Start() {
-	dr.startTime = time.Now()
-}
-
-func (dr *DurationRecorder) Stop() {
-	recordedDuration := time.Since(dr.startTime)
-	if dr.elapsed != nil {
-		dr.elapsed.With(dr.labels).Observe(recordedDuration.Seconds())
-	}
 }
 
 var (

--- a/internal/controller/receptor.go
+++ b/internal/controller/receptor.go
@@ -11,7 +11,6 @@ import (
 	"github.com/RedHatInsights/platform-receptor-controller/internal/receptor/protocol"
 
 	"github.com/google/uuid"
-	"github.com/prometheus/client_golang/prometheus"
 	kafka "github.com/segmentio/kafka-go"
 
 	"github.com/sirupsen/logrus"
@@ -144,17 +143,12 @@ func (r *ReceptorService) Ping(msgSenderCtx context.Context, account string, rec
 	msgSenderCtx, cancel := context.WithTimeout(msgSenderCtx, r.config.ReceptorSyncPingTimeout)
 	defer cancel()
 
-	pingDurationRecorder := DurationRecorder{elapsed: metrics.pingElapsed,
-		labels: prometheus.Labels{"account": r.AccountNumber, "recipient": r.PeerNodeID}}
-	pingDurationRecorder.Start()
-
 	err = r.sendControlMessage(msgSenderCtx, payloadMessage)
 	if err != nil {
 		return nil, err
 	}
 
 	responseMsg, err := r.waitForResponse(msgSenderCtx, responseChannel)
-	pingDurationRecorder.Stop()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I originally implemented this using labels which were used to track the account number and node id.  I don't think this is a great approach as eventually we might have a high number of accounts and node ids.  This approach might cause the metrics system to have issues due to the (potential amount of data).