### PR TITLE
Pass the context into the ConnectionRegistrar and ConnectionLocator methods

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -32,10 +32,11 @@ const (
 
 func closeConnections(cm c.ConnectionLocator, wg *sync.WaitGroup, timeout time.Duration) {
 	defer wg.Done()
-	connections := cm.GetAllConnections()
+	ctx := context.TODO()
+	connections := cm.GetAllConnections(ctx)
 	for _, conn := range connections {
 		for _, client := range conn {
-			client.Close(context.TODO())
+			client.Close(ctx)
 		}
 	}
 	time.Sleep(timeout)

--- a/internal/controller/api/http_proxy_connection_manager.go
+++ b/internal/controller/api/http_proxy_connection_manager.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"context"
+
 	"github.com/RedHatInsights/platform-receptor-controller/internal/config"
 	"github.com/RedHatInsights/platform-receptor-controller/internal/controller"
 	"github.com/RedHatInsights/platform-receptor-controller/internal/platform/logger"
@@ -14,7 +16,7 @@ type RedisConnectionLocator struct {
 	Cfg    *config.Config
 }
 
-func (rcl *RedisConnectionLocator) GetConnection(account string, node_id string) controller.Receptor {
+func (rcl *RedisConnectionLocator) GetConnection(ctx context.Context, account string, node_id string) controller.Receptor {
 	var conn controller.Receptor
 	var podName string
 	var err error
@@ -41,7 +43,7 @@ func (rcl *RedisConnectionLocator) GetConnection(account string, node_id string)
 	return conn
 }
 
-func (rcl *RedisConnectionLocator) GetConnectionsByAccount(account string) map[string]controller.Receptor {
+func (rcl *RedisConnectionLocator) GetConnectionsByAccount(ctx context.Context, account string) map[string]controller.Receptor {
 
 	log := logger.Log.WithFields(logrus.Fields{"account": account})
 
@@ -54,14 +56,14 @@ func (rcl *RedisConnectionLocator) GetConnectionsByAccount(account string) map[s
 	}
 
 	for nodeID, _ := range accountConnections {
-		proxy := rcl.GetConnection(account, nodeID)
+		proxy := rcl.GetConnection(ctx, account, nodeID)
 		connectionsPerAccount[nodeID] = proxy
 	}
 
 	return connectionsPerAccount
 }
 
-func (rcl *RedisConnectionLocator) GetAllConnections() map[string]map[string]controller.Receptor {
+func (rcl *RedisConnectionLocator) GetAllConnections(ctx context.Context) map[string]map[string]controller.Receptor {
 
 	connectionMap := make(map[string]map[string]controller.Receptor)
 
@@ -76,7 +78,7 @@ func (rcl *RedisConnectionLocator) GetAllConnections() map[string]map[string]con
 			connectionMap[account] = make(map[string]controller.Receptor)
 		}
 		for node, _ := range conn {
-			proxy := rcl.GetConnection(account, node)
+			proxy := rcl.GetConnection(ctx, account, node)
 			connectionMap[account][node] = proxy
 		}
 	}

--- a/internal/controller/api/http_proxy_connection_manager_test.go
+++ b/internal/controller/api/http_proxy_connection_manager_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"testing"
 
 	"github.com/RedHatInsights/platform-receptor-controller/internal/config"
@@ -55,7 +56,7 @@ func TestGetConnection(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		conn := locator.GetConnection(tc.account, tc.nodeID)
+		conn := locator.GetConnection(context.TODO(), tc.account, tc.nodeID)
 		assert.Equal(t, conn, tc.expectedConn)
 	}
 }
@@ -114,7 +115,7 @@ func TestGetConnectionsByAccount(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		res := locator.GetConnectionsByAccount(tc.account)
+		res := locator.GetConnectionsByAccount(context.TODO(), tc.account)
 		assert.Equal(t, res, tc.expectedConns)
 	}
 }
@@ -134,7 +135,7 @@ func TestGetAllConnections(t *testing.T) {
 	_ = controller.RegisterWithRedis(c, "01", "node-b", "localhost")
 	_ = controller.RegisterWithRedis(c, "02", "node-c", "localhost")
 
-	res := locator.GetAllConnections()
+	res := locator.GetAllConnections(context.TODO())
 
 	assert.Equal(t, map[string]map[string]controller.Receptor{
 		"01": {

--- a/internal/controller/api/job_receiver.go
+++ b/internal/controller/api/job_receiver.go
@@ -70,7 +70,7 @@ func (jr *JobReceiver) handleJob() http.HandlerFunc {
 		}
 
 		var client controller.Receptor
-		client = jr.connectionMgr.GetConnection(jobRequest.Account, jobRequest.Recipient)
+		client = jr.connectionMgr.GetConnection(req.Context(), jobRequest.Account, jobRequest.Recipient)
 		if client == nil {
 			// The connection to the customer's receptor node was not available
 			errMsg := "No connection to the receptor node"

--- a/internal/controller/api/job_receiver_test.go
+++ b/internal/controller/api/job_receiver_test.go
@@ -69,9 +69,9 @@ var _ = Describe("JobReceiver", func() {
 		apiMux := mux.NewRouter()
 		cm := controller.NewLocalConnectionManager()
 		mc := MockClient{}
-		cm.Register("1234", "345", mc)
+		cm.Register(context.TODO(), "1234", "345", mc)
 		errorMC := MockClient{returnAnError: true}
-		cm.Register("1234", "error-client", errorMC)
+		cm.Register(context.TODO(), "1234", "error-client", errorMC)
 		cfg := config.GetConfig()
 		jr = NewJobReceiver(cm, apiMux, cfg)
 		jr.Routes()

--- a/internal/controller/api/management.go
+++ b/internal/controller/api/management.go
@@ -86,7 +86,7 @@ func (s *ManagementServer) handleDisconnect() http.HandlerFunc {
 			return
 		}
 
-		client := s.connectionMgr.GetConnection(connID.Account, connID.NodeID)
+		client := s.connectionMgr.GetConnection(req.Context(), connID.Account, connID.NodeID)
 		if client == nil {
 			errMsg := fmt.Sprintf("No connection found for node (%s:%s)", connID.Account, connID.NodeID)
 			logger.Info(errMsg)
@@ -133,7 +133,7 @@ func (s *ManagementServer) handleConnectionStatus() http.HandlerFunc {
 
 		connectionStatus := connectionStatusResponse{Status: DISCONNECTED_STATUS}
 
-		client := s.connectionMgr.GetConnection(connID.Account, connID.NodeID)
+		client := s.connectionMgr.GetConnection(req.Context(), connID.Account, connID.NodeID)
 		if client != nil {
 			capabilities, err := client.GetCapabilities(req.Context())
 			if err == nil {
@@ -181,7 +181,7 @@ func (s *ManagementServer) handleConnectionPing() http.HandlerFunc {
 			connID.Account, connID.NodeID)
 
 		pingResponse := connectionPingResponse{Status: DISCONNECTED_STATUS}
-		client := s.connectionMgr.GetConnection(connID.Account, connID.NodeID)
+		client := s.connectionMgr.GetConnection(req.Context(), connID.Account, connID.NodeID)
 		if client == nil {
 			writeJSONResponse(w, http.StatusOK, pingResponse)
 			return
@@ -223,7 +223,7 @@ func (s *ManagementServer) handleConnectionListing() http.HandlerFunc {
 
 		logger.Debugf("Getting connection list")
 
-		allReceptorConnections := s.connectionMgr.GetAllConnections()
+		allReceptorConnections := s.connectionMgr.GetAllConnections(req.Context())
 
 		connections := make([]ConnectionsPerAccount, len(allReceptorConnections))
 
@@ -263,7 +263,7 @@ func (s *ManagementServer) handleConnectionListingByAccount() http.HandlerFunc {
 
 		logger.Debug("Getting connections for ", accountId)
 
-		accountConnections := s.connectionMgr.GetConnectionsByAccount(accountId)
+		accountConnections := s.connectionMgr.GetConnectionsByAccount(req.Context(), accountId)
 		connections := make([]string, len(accountConnections))
 
 		connCount := 0

--- a/internal/controller/api/management_test.go
+++ b/internal/controller/api/management_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -65,7 +66,7 @@ var _ = Describe("Management", func() {
 		apiMux := mux.NewRouter()
 		cm = controller.NewLocalConnectionManager()
 		mc := MockClient{}
-		cm.Register(CONNECTED_ACCOUNT_NUMBER, CONNECTED_NODE_ID, mc)
+		cm.Register(context.TODO(), CONNECTED_ACCOUNT_NUMBER, CONNECTED_NODE_ID, mc)
 		cfg := config.GetConfig()
 		ms = NewManagementServer(cm, apiMux, cfg)
 		ms.Routes()

--- a/internal/controller/connection_manager.go
+++ b/internal/controller/connection_manager.go
@@ -25,14 +25,14 @@ func (d DuplicateConnectionError) Error() string {
 }
 
 type ConnectionRegistrar interface {
-	Register(account string, node_id string, client Receptor) error
-	Unregister(account string, node_id string)
+	Register(ctx context.Context, account string, node_id string, client Receptor) error
+	Unregister(ctx context.Context, account string, node_id string)
 }
 
 type ConnectionLocator interface {
-	GetConnection(account string, node_id string) Receptor
-	GetConnectionsByAccount(account string) map[string]Receptor
-	GetAllConnections() map[string]map[string]Receptor
+	GetConnection(ctx context.Context, account string, node_id string) Receptor
+	GetConnectionsByAccount(ctx context.Context, account string) map[string]Receptor
+	GetAllConnections(ctx context.Context) map[string]map[string]Receptor
 }
 
 type LocalConnectionManager struct {
@@ -46,7 +46,7 @@ func NewLocalConnectionManager() *LocalConnectionManager {
 	}
 }
 
-func (cm *LocalConnectionManager) Register(account string, node_id string, client Receptor) error {
+func (cm *LocalConnectionManager) Register(ctx context.Context, account string, node_id string, client Receptor) error {
 	cm.Lock()
 	defer cm.Unlock()
 	_, exists := cm.connections[account]
@@ -68,7 +68,7 @@ func (cm *LocalConnectionManager) Register(account string, node_id string, clien
 	return nil
 }
 
-func (cm *LocalConnectionManager) Unregister(account string, node_id string) {
+func (cm *LocalConnectionManager) Unregister(ctx context.Context, account string, node_id string) {
 	cm.Lock()
 	defer cm.Unlock()
 	_, exists := cm.connections[account]
@@ -84,7 +84,7 @@ func (cm *LocalConnectionManager) Unregister(account string, node_id string) {
 	logger.Log.Printf("Unregistered a connection (%s, %s)", account, node_id)
 }
 
-func (cm *LocalConnectionManager) GetConnection(account string, node_id string) Receptor {
+func (cm *LocalConnectionManager) GetConnection(ctx context.Context, account string, node_id string) Receptor {
 	var conn Receptor
 
 	cm.RLock()
@@ -102,7 +102,7 @@ func (cm *LocalConnectionManager) GetConnection(account string, node_id string) 
 	return conn
 }
 
-func (cm *LocalConnectionManager) GetConnectionsByAccount(account string) map[string]Receptor {
+func (cm *LocalConnectionManager) GetConnectionsByAccount(ctx context.Context, account string) map[string]Receptor {
 	cm.RLock()
 	defer cm.RUnlock()
 
@@ -120,7 +120,7 @@ func (cm *LocalConnectionManager) GetConnectionsByAccount(account string) map[st
 	return connectionsPerAccount
 }
 
-func (cm *LocalConnectionManager) GetAllConnections() map[string]map[string]Receptor {
+func (cm *LocalConnectionManager) GetAllConnections(ctx context.Context) map[string]map[string]Receptor {
 	cm.RLock()
 	defer cm.RUnlock()
 

--- a/internal/controller/connection_manager_test.go
+++ b/internal/controller/connection_manager_test.go
@@ -38,7 +38,7 @@ func (mr *MockReceptor) GetCapabilities(context.Context) (interface{}, error) {
 func TestCheckForLocalConnectionThatDoesNotExist(t *testing.T) {
 	var cl ConnectionLocator
 	cl = NewLocalConnectionManager()
-	receptorConnection := cl.GetConnection("not gonna find me", "or me")
+	receptorConnection := cl.GetConnection(context.TODO(), "not gonna find me", "or me")
 	if receptorConnection != nil {
 		t.Fatalf("Expected to not find a connection, but a connection was found")
 	}
@@ -47,8 +47,8 @@ func TestCheckForLocalConnectionThatDoesNotExist(t *testing.T) {
 func TestCheckForLocalConnectionThatDoesNotExistButAccountExists(t *testing.T) {
 	registeredAccount := "123"
 	lcm := NewLocalConnectionManager()
-	lcm.Register(registeredAccount, "456", &MockReceptor{})
-	receptorConnection := lcm.GetConnection(registeredAccount, "not gonna find me")
+	lcm.Register(context.TODO(), registeredAccount, "456", &MockReceptor{})
+	receptorConnection := lcm.GetConnection(context.TODO(), registeredAccount, "not gonna find me")
 	if receptorConnection != nil {
 		t.Fatalf("Expected to not find a connection, but a connection was found")
 	}
@@ -57,8 +57,8 @@ func TestCheckForLocalConnectionThatDoesNotExistButAccountExists(t *testing.T) {
 func TestCheckForLocalConnectionThatDoesExist(t *testing.T) {
 	mockReceptor := &MockReceptor{}
 	cm := NewLocalConnectionManager()
-	cm.Register("123", "456", mockReceptor)
-	receptorConnection := cm.GetConnection("123", "456")
+	cm.Register(context.TODO(), "123", "456", mockReceptor)
+	receptorConnection := cm.GetConnection(context.TODO(), "123", "456")
 	if receptorConnection == nil {
 		t.Fatalf("Expected to find a connection, but did not find a connection")
 	}
@@ -80,9 +80,9 @@ func TestRegisterAndUnregisterMultipleLocalConnectionsPerAccount(t *testing.T) {
 	}
 	cm := NewLocalConnectionManager()
 	for _, r := range testReceptors {
-		cm.Register(r.account, r.node_id, r.receptor)
+		cm.Register(context.TODO(), r.account, r.node_id, r.receptor)
 
-		actualReceptor := cm.GetConnection(r.account, r.node_id)
+		actualReceptor := cm.GetConnection(context.TODO(), r.account, r.node_id)
 		if actualReceptor == nil {
 			t.Fatalf("Expected to find a connection, but did not find a connection")
 		}
@@ -93,13 +93,13 @@ func TestRegisterAndUnregisterMultipleLocalConnectionsPerAccount(t *testing.T) {
 	}
 
 	for _, r := range testReceptors {
-		cm.Unregister(r.account, r.node_id)
+		cm.Unregister(context.TODO(), r.account, r.node_id)
 	}
 }
 
 func TestUnregisterLocalConnectionThatDoesNotExist(t *testing.T) {
 	cm := NewLocalConnectionManager()
-	cm.Unregister("not gonna find me", "or me")
+	cm.Unregister(context.TODO(), "not gonna find me", "or me")
 }
 
 func TestGetLocalConnectionsByAccount(t *testing.T) {
@@ -114,10 +114,10 @@ func TestGetLocalConnectionsByAccount(t *testing.T) {
 	}
 	cm := NewLocalConnectionManager()
 	for _, r := range testReceptors {
-		cm.Register(r.account, r.node_id, r.receptor)
+		cm.Register(context.TODO(), r.account, r.node_id, r.receptor)
 	}
 
-	receptorMap := cm.GetConnectionsByAccount(accountNumber)
+	receptorMap := cm.GetConnectionsByAccount(context.TODO(), accountNumber)
 	if len(receptorMap) != len(testReceptors) {
 		t.Fatalf("Expected to find %d connections, but found %d connections", len(testReceptors), len(receptorMap))
 	}
@@ -125,7 +125,7 @@ func TestGetLocalConnectionsByAccount(t *testing.T) {
 
 func TestGetLocalConnectionsByAccountWithNoRegisteredReceptors(t *testing.T) {
 	cm := NewLocalConnectionManager()
-	receptorMap := cm.GetConnectionsByAccount("0000001")
+	receptorMap := cm.GetConnectionsByAccount(context.TODO(), "0000001")
 	if len(receptorMap) != 0 {
 		t.Fatalf("Expected to find 0 connections, but found %d connections", len(receptorMap))
 	}
@@ -142,11 +142,11 @@ func TestGetAllLocalConnections(t *testing.T) {
 	cm := NewLocalConnectionManager()
 	for account, receptorMap := range testReceptors {
 		for nodeID, receptor := range receptorMap {
-			cm.Register(account, nodeID, receptor)
+			cm.Register(context.TODO(), account, nodeID, receptor)
 		}
 	}
 
-	receptorMap := cm.GetAllConnections()
+	receptorMap := cm.GetAllConnections(context.TODO())
 
 	if cmp.Equal(testReceptors, receptorMap) != true {
 		t.Fatalf("Excepted receptor map and actual receptor map do not match.  Excpected %+v, Actual %+v",
@@ -156,7 +156,7 @@ func TestGetAllLocalConnections(t *testing.T) {
 
 func TestGetAllLocalConnectionsWithNoRegisteredReceptors(t *testing.T) {
 	cm := NewLocalConnectionManager()
-	receptorMap := cm.GetAllConnections()
+	receptorMap := cm.GetAllConnections(context.TODO())
 	if len(receptorMap) != 0 {
 		t.Fatalf("Expected to find 0 connections, but found %d connections", len(receptorMap))
 	}
@@ -175,17 +175,17 @@ func TestRegisterLocalConnectionsWithDuplicateNodeIDs(t *testing.T) {
 
 	cm := NewLocalConnectionManager()
 
-	err := cm.Register(accountNumber, nodeID, expectedReceptorObj)
+	err := cm.Register(context.TODO(), accountNumber, nodeID, expectedReceptorObj)
 	if err != nil {
 		t.Fatalf("Expected the error to be nil")
 	}
 
-	err = cm.Register(accountNumber, nodeID, secondReceptorObj)
+	err = cm.Register(context.TODO(), accountNumber, nodeID, secondReceptorObj)
 	if err == nil {
 		t.Fatalf("Expected an error instance to be returned in the case of duplicate registration")
 	}
 
-	actualReceptorObj := cm.GetConnection(accountNumber, nodeID)
+	actualReceptorObj := cm.GetConnection(context.TODO(), accountNumber, nodeID)
 
 	if actualReceptorObj != expectedReceptorObj {
 		t.Fatalf("Expected to find the connection that was registered first")

--- a/internal/controller/disconnect_handler.go
+++ b/internal/controller/disconnect_handler.go
@@ -16,7 +16,7 @@ type DisconnectHandler struct {
 }
 
 func (dh DisconnectHandler) HandleMessage(ctx context.Context, m protocol.Message) {
-	dh.ConnectionMgr.Unregister(dh.AccountNumber, dh.NodeID)
+	dh.ConnectionMgr.Unregister(ctx, dh.AccountNumber, dh.NodeID)
 	dh.Logger.Debugf("DisconnectHandler - account (%s) / node id (%s) unregistered from connection manager",
 		dh.AccountNumber,
 		dh.NodeID)

--- a/internal/controller/handshake_handler.go
+++ b/internal/controller/handshake_handler.go
@@ -66,7 +66,7 @@ func (hh HandshakeHandler) HandleMessage(ctx context.Context, m protocol.Message
 
 	receptor.RegisterConnection(hiMessage.ID, hiMessage.Metadata, hh.Transport)
 
-	err := hh.ConnectionMgr.Register(hh.AccountNumber, hiMessage.ID, receptor)
+	err := hh.ConnectionMgr.Register(hh.Transport.Ctx, hh.AccountNumber, hiMessage.ID, receptor)
 	if err != nil {
 		// Abort the connection if this account number and node id are already registered
 		hh.Logger.WithFields(logrus.Fields{"error": err}).Infof("Unable to register connection "+


### PR DESCRIPTION
This change makes it so that a context is passed along on the ConnectionRegistrar and ConnectionLocator methods.