### PR TITLE
Moving a responsibility around

### DIFF
--- a/internal/controller/payload_handler.go
+++ b/internal/controller/payload_handler.go
@@ -30,12 +30,6 @@ func (ph PayloadHandler) HandleMessage(ctx context.Context, m protocol.Message) 
 		return
 	}
 
-	// verify this message was meant for this receptor/peer (probably want a uuid here)
-	if payloadMessage.RoutingInfo.Recipient != ph.Receptor.NodeID {
-		ph.Logger.Info("Recieved message that was not intended for this node")
-		return
-	}
-
 	ph.Receptor.DispatchResponse(payloadMessage)
 
 	return

--- a/internal/controller/receptor.go
+++ b/internal/controller/receptor.go
@@ -228,6 +228,14 @@ func (r *ReceptorService) DispatchResponse(payloadMessage *protocol.PayloadMessa
 	logger := r.logger.WithFields(logrus.Fields{"in_response_to": payloadMessage.Data.InResponseTo,
 		"message_id": payloadMessage.Data.MessageID})
 
+	// verify this message was meant for this receptor/peer
+	if payloadMessage.RoutingInfo.Recipient != r.NodeID {
+		logger.WithFields(
+			logrus.Fields{"recipient": payloadMessage.RoutingInfo.Recipient,
+				"sender": payloadMessage.RoutingInfo.Sender}).Info("Recieved message that was not intended for this node.  Discarding message.")
+		return
+	}
+
 	responseMessage := ResponseMessage{
 		AccountNumber: r.AccountNumber,
 		Sender:        payloadMessage.RoutingInfo.Sender,


### PR DESCRIPTION
The payload handler was taking some of the responsibilities that should be part of the receptor response dispatcher

TODO: once #148 is merged in, modify the logger that is used in this PR to be the "logger" instance and not "r.logger"