### PR TITLE
Adding readiness and liveness endpoints

### DIFF
--- a/internal/controller/api/management.go
+++ b/internal/controller/api/management.go
@@ -3,7 +3,6 @@ package api
 import (
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 
 	"github.com/RedHatInsights/platform-receptor-controller/internal/config"
 	"github.com/RedHatInsights/platform-receptor-controller/internal/controller"
@@ -43,10 +42,6 @@ func (s *ManagementServer) Routes() {
 	securedSubRouter.HandleFunc("/disconnect", s.handleDisconnect()).Methods(http.MethodPost)
 	securedSubRouter.HandleFunc("/status", s.handleConnectionStatus()).Methods(http.MethodPost)
 	securedSubRouter.HandleFunc("/ping", s.handleConnectionPing()).Methods(http.MethodPost)
-	if s.config.Profile {
-		logger.Log.Warn("WARNING: Enabling the profiler endpoint!!")
-		s.router.PathPrefix("/debug").Handler(http.DefaultServeMux)
-	}
 }
 
 type connectionID struct {

--- a/internal/controller/api/monitoring.go
+++ b/internal/controller/api/monitoring.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"net/http"
+	_ "net/http/pprof"
+
+	"github.com/RedHatInsights/platform-receptor-controller/internal/config"
+	"github.com/RedHatInsights/platform-receptor-controller/internal/platform/logger"
+
+	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+type MonitoringServer struct {
+	router *mux.Router
+	config *config.Config
+}
+
+func NewMonitoringServer(r *mux.Router, cfg *config.Config) *MonitoringServer {
+	return &MonitoringServer{
+		router: r,
+		config: cfg,
+	}
+}
+
+func (s *MonitoringServer) Routes() {
+	s.router.Handle("/metrics", promhttp.Handler()).Methods(http.MethodGet)
+	s.router.HandleFunc("/liveness", s.handleLiveness()).Methods(http.MethodGet)
+	s.router.HandleFunc("/readiness", s.handleReadiness()).Methods(http.MethodGet)
+
+	if s.config.Profile {
+		logger.Log.Warn("WARNING: Enabling the profiler endpoint!!")
+		s.router.PathPrefix("/debug").Handler(http.DefaultServeMux)
+	}
+}
+
+func (s *MonitoringServer) handleLiveness() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func (s *MonitoringServer) handleReadiness() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+}

--- a/internal/controller/api/monitoring_test.go
+++ b/internal/controller/api/monitoring_test.go
@@ -1,0 +1,69 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/RedHatInsights/platform-receptor-controller/internal/config"
+
+	"github.com/go-playground/assert/v2"
+	"github.com/gorilla/mux"
+)
+
+func TestMonitoringEndpoints(t *testing.T) {
+	tests := []struct {
+		endpoint       string
+		httpMethod     string
+		expectedStatus int
+	}{
+		{
+			endpoint:       "/metrics",
+			httpMethod:     "GET",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			endpoint:       "/metrics",
+			httpMethod:     "POST",
+			expectedStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			endpoint:       "/liveness",
+			httpMethod:     "GET",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			endpoint:       "/liveness",
+			httpMethod:     "POST",
+			expectedStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			endpoint:       "/readiness",
+			httpMethod:     "GET",
+			expectedStatus: http.StatusOK,
+		},
+		{
+			endpoint:       "/readiness",
+			httpMethod:     "POST",
+			expectedStatus: http.StatusMethodNotAllowed,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.httpMethod+" "+tc.endpoint, func(t *testing.T) {
+			req, err := http.NewRequest(tc.httpMethod, tc.endpoint, nil)
+			assert.Equal(t, err, nil)
+
+			rr := httptest.NewRecorder()
+
+			cfg := config.GetConfig()
+			apiMux := mux.NewRouter()
+			apiSpecServer := NewMonitoringServer(apiMux, cfg)
+			apiSpecServer.Routes()
+
+			apiSpecServer.router.ServeHTTP(rr, req)
+
+			assert.Equal(t, rr.Code, tc.expectedStatus)
+		})
+	}
+}


### PR DESCRIPTION
Created a new MonitoringServer object
Movied /metrics endpoint to the MonitoringServer object
Added /liveness and /readiness endpoint to the MonitoringServer object
Modified the servers to send a ping request to redis during startup (failing this ping will cause the servers to fail to start)

For now, the /liveness and /readiness endpoints do not check for redis or kafka to be running.  At this point, I do not want what could be transient failures to cause pods to get shutdown (https://blog.colinbreck.com/kubernetes-liveness-and-readiness-probes-how-to-avoid-shooting-yourself-in-the-foot/#shootingyourselfinthefootwithreadinessprobes).  Having pods go down would cause websocket connections to get dropped.  If there are a high number of active websocket connections, dropping the connections could cause a sizable re-connection event (thundering herd) which might lead to issues.

The liveness and readiness endpoints are separate to allow for customization later on if needed.