### PR TITLE
fix: remove unneeded packages from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ RUN go build -o connection-util ./cmd/connection_util/main.go
 
 RUN go build -o response-consumer ./cmd/response_consumer/main.go
 
+RUN REMOVE_PKGS="binutils kernel-headers" && \
+    yum remove -y $REMOVE_PKGS && \
+    yum clean all 
+
 USER 1001
 
 EXPOSE 8000 9000 8081


### PR DESCRIPTION
These are a couple packages that have been caught in security
vulnerabilities several times. We dont' need them after compiling our
images, so we can throw them away when done.

Signed-off-by: Stephen Adams <tsadams@gmail.com>