### PR TITLE
fix: Remove nodejs dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN go build -o connection-util ./cmd/connection_util/main.go
 
 RUN go build -o response-consumer ./cmd/response_consumer/main.go
 
-RUN REMOVE_PKGS="binutils kernel-headers" && \
+RUN REMOVE_PKGS="binutils kernel-headers nodejs nodejs-full-i18n npm" && \
     yum remove -y $REMOVE_PKGS && \
     yum clean all 
 


### PR DESCRIPTION
This is a go app. We don't need `node` on this box.

Signed-off-by: Stephen Adams <tsadams@gmail.com>