### PR TITLE
Update pr_check.sh to match template

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -14,17 +14,8 @@ IQE_FILTER_EXPRESSION=""
 
 # Install bonfire repo/initialize
 CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
-curl -s $CICD_URL/bootstrap.sh -o bootstrap.sh
-source bootstrap.sh  # checks out bonfire and changes to "cicd" dir...
+curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 
-source build.sh
-source deploy_ephemeral_env.sh
-source smoke_test.sh
-
-# Need to make a dummy results file to make tests pass
-mkdir -p artifacts
-cat << EOF > artifacts/junit-dummy.xml
-<testsuite tests="1">
-    <testcase classname="dummy" name="dummytest"/>
-</testsuite>
-EOF
+source $CICD_ROOT/build.sh
+source $CICD_ROOT/deploy_ephemeral_env.sh
+source $CICD_ROOT/smoke_test.sh


### PR DESCRIPTION
We are switching to using absoute dir paths to avoid confusion.

I also don't think you need the dummy junit.xml unless your smoke tests are currently generating no test results (in which case, we should just disable those tests until they actually provide results)