### PR TITLE
[dockerfile] use builder image for builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM registry.redhat.io/ubi8/go-toolset
+# Use go-toolset as the builder image
+# Once built, copy to a smaller image and run from there
+FROM registry.redhat.io/ubi8/go-toolset as builder
 
 WORKDIR /go/src/app
 
@@ -20,9 +22,17 @@ RUN go build -o connection-util ./cmd/connection_util/main.go
 
 RUN go build -o response-consumer ./cmd/response_consumer/main.go
 
-RUN REMOVE_PKGS="binutils kernel-headers nodejs nodejs-full-i18n npm" && \
-    yum remove -y $REMOVE_PKGS && \
-    yum clean all 
+# Using ubi8-minimal due to its smaller footprint
+FROM registry.redhat.io/ubi8/ubi-minimal
+
+WORKDIR /
+
+# Copy executable files from the builder image
+COPY --from=builder /go/src/app/gateway /gateway
+COPY --from=builder /go/src/app/connection-cleaner /connection-cleaner
+COPY --from=builder /go/src/app/job-receiver /job-receiver
+COPY --from=builder /go/src/app/connection-util /connection-util
+COPY --from=builder /go/src/app/response-consumer /response-consumer
 
 USER 1001
 


### PR DESCRIPTION
Switching to using a builder image and run image for builds. This
basically allows us to used a much smaller image at runtime without all
the bulk needed by a build container that needs dev tools.

All executables are moved to a minimal container reducing our footprint
as well as our security surface.

Signed-off-by: Stephen Adams <tsadams@gmail.com>